### PR TITLE
Add Plateau coverage area display layer (zoom 5-14)

### DIFF
--- a/modules/pixi/PixiLayerPlateauCoverage.js
+++ b/modules/pixi/PixiLayerPlateauCoverage.js
@@ -1,0 +1,141 @@
+import { AbstractLayer } from './AbstractLayer.js';
+import { PixiFeaturePolygon } from './PixiFeaturePolygon.js';
+
+
+const LAYERID = 'plateau-coverage';
+const MINZOOM = 5;
+const MAXZOOM = 14;
+// Vivid orange — colorblind-safe (IBM Accessible Color Palette),
+// stands out against Japan's green-heavy OSM background (forests, parks).
+const PLATEAU_COVERAGE_COLOR = 0xFE6100;
+
+
+/**
+ * PixiLayerPlateauCoverage
+ * Shows where Plateau building data exists, as semi-transparent polygons.
+ *
+ * Each polygon is a convex hull of one city's building centroids,
+ * fetched from the rapid_plateau_api server.
+ *
+ * Visible at zoom 5-14. Above zoom 14, the actual building data starts
+ * loading (see PixiLayerRapid), so this overview layer hides itself.
+ *
+ * @class
+ */
+export class PixiLayerPlateauCoverage extends AbstractLayer {
+
+  /**
+   * @constructor
+   * @param  scene    The Scene that owns this Layer
+   * @param  layerID  Unique string to use for the name of this Layer
+   */
+  constructor(scene, layerID) {
+    super(scene, layerID);
+    this._enabled = true;          // Default ON
+    this._fetched = false;         // True after we've attempted the initial fetch
+  }
+
+
+  /**
+   * supported
+   * @return {boolean} `true` if the mapwithai service is available
+   */
+  get supported() {
+    return !!this.context.services.mapwithai;
+  }
+
+
+  /**
+   * reset
+   * Every Layer should have a reset function to replace any Pixi objects and internal state.
+   */
+  reset() {
+    super.reset();
+  }
+
+
+  /**
+   * render
+   * Draw the coverage polygons at appropriate zoom levels.
+   * @param  frame      Integer frame being rendered
+   * @param  viewport   Pixi viewport to use for rendering
+   * @param  zoom       Effective zoom to use for rendering
+   */
+  render(frame, viewport, zoom) {
+    if (!this.enabled) return;
+    if (zoom < MINZOOM || zoom > MAXZOOM) return;
+
+    const service = this.context.services.mapwithai;
+    if (!service) return;
+
+    // Trigger fetch once. Promise resolves with FeatureCollection or null.
+    // Until it resolves, we have nothing to draw — re-render will pick it up.
+    if (!this._fetched) {
+      this._fetched = true;
+      service.loadCoverage().then(data => {
+        if (data) {
+          this.context.systems.gfx.deferredRedraw();
+        }
+      });
+    }
+
+    // Read cached data from the service
+    const data = service._coverageData;
+    if (!data || !data.features) return;
+
+    this._renderFeatures(frame, viewport, zoom, data.features);
+  }
+
+
+  /**
+   * _renderFeatures
+   * @param  frame      Integer frame being rendered
+   * @param  viewport   Pixi viewport to use for rendering
+   * @param  zoom       Effective zoom to use for rendering
+   * @param  features   Array of GeoJSON Features
+   */
+  _renderFeatures(frame, viewport, zoom, features) {
+    const parentContainer = this.scene.groups.get('basemap');
+
+    const style = {
+      fill: { color: PLATEAU_COVERAGE_COLOR, alpha: 0.15 },
+      stroke: { width: 1.5, color: PLATEAU_COVERAGE_COLOR, alpha: 0.6, cap: 'round' },
+      labelTint: PLATEAU_COVERAGE_COLOR
+    };
+
+    for (const feat of features) {
+      if (!feat || !feat.geometry) continue;
+
+      const props = feat.properties || {};
+      const cityCode = feat.id || props.city_code || 'unknown';
+
+      // Support Polygon and MultiPolygon
+      const parts = (feat.geometry.type === 'Polygon') ? [feat.geometry.coordinates]
+        : (feat.geometry.type === 'MultiPolygon') ? feat.geometry.coordinates
+        : [];
+
+      for (let i = 0; i < parts.length; ++i) {
+        const coords = parts[i];
+        const featureID = `${this.layerID}-${cityCode}-${i}`;
+
+        let pixiFeature = this.features.get(featureID);
+        if (pixiFeature && pixiFeature.type !== 'polygon') {
+          pixiFeature.destroy();
+          pixiFeature = null;
+        }
+
+        if (!pixiFeature) {
+          pixiFeature = new PixiFeaturePolygon(this, featureID);
+          pixiFeature.style = style;
+          pixiFeature.parentContainer = parentContainer;
+          pixiFeature.geometry.setCoords(coords);
+          pixiFeature.setData(cityCode, feat);
+        }
+
+        this.syncFeatureClasses(pixiFeature);
+        pixiFeature.update(viewport, zoom);
+        this.retainFeature(pixiFeature, frame);
+      }
+    }
+  }
+}

--- a/modules/pixi/PixiScene.js
+++ b/modules/pixi/PixiScene.js
@@ -15,6 +15,7 @@ import { PixiLayerMapUI } from './PixiLayerMapUI.js';
 import { PixiLayerOsm } from './PixiLayerOsm.js';
 import { PixiLayerOsmNotes } from './PixiLayerOsmNotes.js';
 import { PixiLayerOsmose } from './PixiLayerOsmose.js';
+import { PixiLayerPlateauCoverage } from './PixiLayerPlateauCoverage.js';
 import { PixiLayerRapid } from './PixiLayerRapid.js';
 import { PixiLayerRapidOverlay } from './PixiLayerRapidOverlay.js';
 import { PixiLayerStreetsidePhotos } from './PixiLayerStreetsidePhotos.js';
@@ -71,6 +72,7 @@ export class PixiScene extends EventEmitter {
       new PixiLayerBackgroundTiles(this, 'background'),
       new PixiLayerGeoScribble(this, 'geoScribble'),
       new PixiLayerOsm(this, 'osm'),
+      new PixiLayerPlateauCoverage(this, 'plateau-coverage'),
       new PixiLayerRapid(this, 'rapid'),
       new PixiLayerRapidOverlay(this, 'rapidoverlay'),
 

--- a/modules/services/MapWithAIService.js
+++ b/modules/services/MapWithAIService.js
@@ -40,6 +40,10 @@ export class MapWithAIService extends AbstractSystem {
       rejected: new Set()    // Set(entityID) - overlapping with OSM
     };
 
+    // Cache for Plateau coverage area GeoJSON (loaded once, used by PixiLayerPlateauCoverage)
+    this._coverageData = null;          // GeoJSON FeatureCollection or null
+    this._coveragePromise = null;       // Promise<FeatureCollection> when inflight
+
     // Ensure methods used as callbacks always have `this` bound correctly.
     this._parseNode = this._parseNode.bind(this);
     this._parseWay = this._parseWay.bind(this);
@@ -205,6 +209,56 @@ export class MapWithAIService extends AbstractSystem {
       };
     }
     return Promise.resolve();
+  }
+
+
+  /**
+   * loadCoverage
+   * Fetch Plateau coverage area GeoJSON once and cache it.
+   * Used by PixiLayerPlateauCoverage to display where Plateau data exists
+   * at zoom 5-14.
+   *
+   * The endpoint returns a FeatureCollection where each Feature is a
+   * convex-hull polygon of one city's buildings, with properties:
+   *   { city_code, building_count }
+   *
+   * @return {Promise<Object|null>}  GeoJSON FeatureCollection, or null on failure
+   */
+  loadCoverage() {
+    // Return cached data immediately if already loaded
+    if (this._coverageData) {
+      return Promise.resolve(this._coverageData);
+    }
+    // Return inflight promise to coalesce concurrent calls
+    if (this._coveragePromise) {
+      return this._coveragePromise;
+    }
+
+    // Derive coverage URL from the buildings URL
+    // PLATEAU_API_URL is .../api/mapwithai/buildings → .../api/mapwithai/coverage
+    const customPlateauUrl = utilStringQs(window.location.hash).plateau_api_url;
+    const buildingsUrl = customPlateauUrl || PLATEAU_API_URL;
+    const coverageUrl = buildingsUrl.replace(/\/buildings(\?.*)?$/, '/coverage');
+
+    this._coveragePromise = fetch(coverageUrl)
+      .then(utilFetchResponse)
+      .then(data => {
+        if (data && data.type === 'FeatureCollection') {
+          this._coverageData = data;
+          return data;
+        }
+        throw new Error('Invalid coverage response');
+      })
+      .catch(err => {
+        // Graceful degradation: log and return null so the layer can hide itself
+        console.warn('Failed to load Plateau coverage:', err);  // eslint-disable-line no-console
+        return null;
+      })
+      .finally(() => {
+        this._coveragePromise = null;
+      });
+
+    return this._coveragePromise;
   }
 
 


### PR DESCRIPTION
## 概要

Closes #9.

Plateau対応エリアを zoom 5〜14 で半透明オレンジのポリゴンで表示する `PixiLayerPlateauCoverage` を追加します。
広域表示でPlateauデータの存在エリアが一目で分かるようになります。

zoom 15 以上では既存の建物データ表示に切り替わるため、本レイヤーは自動的に非表示になります。

## スクリーンショット

zoom 6 で日本全体を表示すると、対応都市が浮き上がります。

## 実装内容

### 1. `modules/services/MapWithAIService.js`
- `loadCoverage()` メソッド追加
- `GET /api/mapwithai/coverage` から GeoJSON を取得
- 結果を `_coverageData` にキャッシュ（1セッションあたり1回のみfetch）
- inflight な Promise を coalesce（同時呼び出しでも fetch は1回）
- 失敗時は graceful degradation: console.warn のみ、UIには影響なし
- URLハッシュ `#plateau_api_url=...` のオーバーライドにも対応

### 2. `modules/pixi/PixiLayerPlateauCoverage.js` (新規)
- `AbstractLayer` を継承
- デフォルト `enabled = true`
- `MINZOOM = 5`, `MAXZOOM = 14` で表示制限
- 初回 render で `loadCoverage()` を非同期で起動、データ到着後に再描画
- スタイル:
  - fill: `#FE6100` (鮮やかなオレンジ) alpha 0.15
  - stroke: `#FE6100` alpha 0.6 width 1.5
- 色は **IBM Accessible Color Palette** から選定。色覚バリアフリー対応で、日本の緑が多いOSM背景でも視認性が高い

### 3. `modules/pixi/PixiScene.js`
- `osm` レイヤーと `rapid` レイヤーの間に `PixiLayerPlateauCoverage` を登録

## サーバ側

本機能はサーバ側に `GET /api/mapwithai/coverage` エンドポイントが必要です:
- リポジトリ: [`nyampire/rapid_plateau_api`](https://github.com/nyampire/rapid_plateau_api)
- 対応PR: [#10](https://github.com/nyampire/rapid_plateau_api/pull/10)
- 実装: マテリアライズドビュー `plateau_coverage` に都市単位の ConcaveHull を保持

サーバAPIが利用できない場合も、本レイヤーは静かに非表示になります（既存機能に影響なし）。

## 本番動作確認

- 表示確認: zoom 5〜14 で半透明オレンジエリアが表示される ✅
- 非表示確認: zoom 15+ で消える ✅
- API レスポンス: 141都市、177KB、約500ms ✅
- 色覚バリアフリー対応: オレンジは緑/青/赤と区別可能 ✅

## デプロイ時の注意

`rapid.min.js` のキャッシュ無効化のため、nginx に以下の設定が必要です（既に適用済み）:

```nginx
location ~* ^/rapid(\.legacy)?(\.min)?\.(js|css)(\.map)?$ {
    add_header Cache-Control "no-cache";
}
```

## ロールバック

簡単に無効化したい場合は、`PixiScene.js` の `new PixiLayerPlateauCoverage(...)` 行を削除するだけでOK。
