### PR TITLE
Phase 3: Parse and cascade-accept type=building relations from MapWithAI

### DIFF
--- a/modules/actions/rapid_accept_feature.js
+++ b/modules/actions/rapid_accept_feature.js
@@ -74,7 +74,8 @@ function removeMetadata(entity) {
 
 export function actionRapidAcceptFeature(entityID, extGraph) {
     return function(graph) {
-        var seenRelations = {};    // keep track of seen relations to avoid infinite recursion
+        var seenRelations = {};       // 完了済 relation (relation→relation 再帰防止 + 結果キャッシュ)
+        var inProgressRelations = {}; // 処理中 relation (way→relation の再 cascade 防止)
         var extEntity = extGraph.entity(entityID);
 
         if (extEntity.type === 'node') {
@@ -103,6 +104,23 @@ export function actionRapidAcceptFeature(entityID, extGraph) {
 
 
         function acceptWay(extWay) {
+            // Phase 3: PLATEAU LOD2 等で `type=building` relation のメンバーとして
+            // 取り込まれた way は、relation 全体 (outline + parts + relation 自体) を
+            // 一括 accept する。これにより orphan building:part way が OSM に
+            // 上がるのを防ぎ、OSM Simple 3D Buildings の構造を維持する。
+            //
+            // 注意: acceptRelation の中で member 各 way に対し acceptWay を再帰呼びする
+            // ため、inProgressRelations で進行中の親 relation への二重 cascade を防ぐ。
+            var parents = extGraph.parentRelations(extWay);
+            for (var i = 0; i < parents.length; i++) {
+                var parent = parents[i];
+                if (parent.tags && parent.tags.type === 'building'
+                    && !seenRelations[parent.id]
+                    && !inProgressRelations[parent.id]) {
+                    return acceptRelation(parent);
+                }
+            }
+
             // copy way before modifying
             var way = osmWay(extWay);
             way.nodes = extWay.nodes.slice();
@@ -153,6 +171,9 @@ export function actionRapidAcceptFeature(entityID, extGraph) {
             var seen = seenRelations[extRelation.id];
             if (seen) return seen;
 
+            // 処理中マーク (member の acceptWay からの再 cascade を防ぐ)
+            inProgressRelations[extRelation.id] = true;
+
             // copy relation before modifying
             var relation = osmRelation(extRelation);
             relation.members = extRelation.members.slice();
@@ -161,6 +182,11 @@ export function actionRapidAcceptFeature(entityID, extGraph) {
 
             var members = relation.members.map(function(member) {
                 var extEntity = extGraph.entity(member.id);
+                if (!extEntity) {
+                    // メンバーが extGraph に存在しない場合 (bbox 外などで dataset graph に入っていない)
+                    // → そのメンバー参照は保持しつつ accept はスキップ
+                    return member;
+                }
                 var replacement;
 
                 if (extEntity.type === 'node') {
@@ -171,12 +197,14 @@ export function actionRapidAcceptFeature(entityID, extGraph) {
                     replacement = acceptRelation(extEntity);
                 }
 
+                if (!replacement) return member;
                 return Object.assign(member, { id: replacement.id });
             });
 
             relation = relation.update({ members: members });
             graph = graph.replace(relation);
             seenRelations[extRelation.id] = relation;
+            delete inProgressRelations[extRelation.id];
             return relation;
         }
 

--- a/modules/services/MapWithAIService.js
+++ b/modules/services/MapWithAIService.js
@@ -4,7 +4,7 @@ import { utilStringQs } from '@rapid-sdk/util';
 
 import { AbstractSystem } from '../core/AbstractSystem.js';
 import { Graph, Tree, RapidDataset } from '../core/lib/index.js';
-import { osmEntity, osmNode, osmWay } from '../osm/index.js';
+import { osmEntity, osmNode, osmRelation, osmWay } from '../osm/index.js';
 import { utilFetchResponse } from '../util/index.js';
 
 
@@ -600,6 +600,25 @@ export class MapWithAIService extends AbstractSystem {
   }
 
 
+  /**
+   * _getMembers
+   * Parse `<member>` children of a relation element into Rapid's member objects.
+   * `id` is prefixed with the type's initial letter (n/w/r), matching osmEntity.id.fromOSM.
+   */
+  _getMembers(xml) {
+    const elems = Array.from(xml.getElementsByTagName('member'));
+    return elems.map(elem => {
+      const attrs = elem.attributes;
+      const type = attrs.type.value;
+      return {
+        id: type[0] + attrs.ref.value,
+        type: type,
+        role: attrs.role?.value ?? ''
+      };
+    });
+  }
+
+
   _getTags(xml) {
     const elems = Array.from(xml.getElementsByTagName('tag'));
     const tags = {};
@@ -647,6 +666,18 @@ export class MapWithAIService extends AbstractSystem {
     return way;
   }
 
+  _parseRelation(obj, uid) {
+    const attrs = obj.attributes;
+    const relation = new osmRelation({
+      id: uid,
+      visible: this._getVisible(attrs),
+      tags: this._getTags(obj),
+      members: this._getMembers(obj),
+    });
+
+    return relation;
+  }
+
 
   _parseXML(dataset, xml, tile, callback) {
     if (!xml || !xml.childNodes) {
@@ -678,7 +709,7 @@ export class MapWithAIService extends AbstractSystem {
     const cache = dataset.cache;
 
     const type = element.nodeName;
-    if (!['node', 'way'].includes(type)) return null;
+    if (!['node', 'way', 'relation'].includes(type)) return null;
 
     let entityID, entity;
     entityID = osmEntity.id.fromOSM(type, element.attributes.id.value);
@@ -718,6 +749,17 @@ export class MapWithAIService extends AbstractSystem {
             cache.seenFirstNodeID.add(firstNodeID);
           }
         }
+      }
+
+    } else if (type === 'relation') {
+      // Phase 3: PLATEAU LOD2 type=building relation (outline + parts) のような
+      // 構造をクライアント graph に取り込む。relation 単独では geometry を持たず
+      // メンバー way がレンダリングを担うため、parse + graph 追加だけで十分。
+      if (cache.seen.has(entityID)) {
+        return null;
+      } else {
+        entity = this._parseRelation(element, entityID);
+        cache.seen.add(entityID);
       }
 
     } else {

--- a/test/browser/services/MapWithAIService.test.js
+++ b/test/browser/services/MapWithAIService.test.js
@@ -124,6 +124,100 @@ describe('MapWithAIService', () => {
   });
 
 
+  describe('#_getMembers', () => {
+    it('extracts member references with type initial prefix and role', () => {
+      const xml = new DOMParser().parseFromString(
+        '<relation>' +
+          '<member type="way" ref="100" role="outline"/>' +
+          '<member type="way" ref="101" role="part"/>' +
+          '<member type="node" ref="200" role=""/>' +
+        '</relation>', 'text/xml'
+      ).documentElement;
+      const members = _service._getMembers(xml);
+      expect(members).to.eql([
+        { id: 'w100', type: 'way', role: 'outline' },
+        { id: 'w101', type: 'way', role: 'part' },
+        { id: 'n200', type: 'node', role: '' }
+      ]);
+    });
+
+    it('handles missing role attribute as empty string', () => {
+      const xml = new DOMParser().parseFromString(
+        '<relation><member type="way" ref="42"/></relation>', 'text/xml'
+      ).documentElement;
+      const members = _service._getMembers(xml);
+      expect(members[0].role).to.eql('');
+    });
+  });
+
+
+  describe('#_parseRelation', () => {
+    it('creates an osmRelation with tags and members', () => {
+      const xml = new DOMParser().parseFromString(
+        '<relation>' +
+          '<member type="way" ref="10" role="outline"/>' +
+          '<member type="way" ref="11" role="part"/>' +
+          '<tag k="type" v="building"/>' +
+          '<tag k="building" v="yes"/>' +
+          '<tag k="height" v="8.4"/>' +
+        '</relation>', 'text/xml'
+      ).documentElement;
+      const rel = _service._parseRelation(xml, 'r-100');
+      expect(rel.id).to.eql('r-100');
+      expect(rel.type).to.eql('relation');
+      expect(rel.tags).to.eql({ type: 'building', building: 'yes', height: '8.4' });
+      expect(rel.members).to.eql([
+        { id: 'w10', type: 'way', role: 'outline' },
+        { id: 'w11', type: 'way', role: 'part' }
+      ]);
+      expect(rel.visible).to.be.true;
+    });
+  });
+
+
+  describe('#_parseEntity for relations', () => {
+    // Phase 3-A: MapWithAIService が `<relation>` を取り込むかの統合テスト
+    const dataset = {
+      id: 'plateauJapan-test',
+      cache: { seen: new Set(), splitWays: new Map(), seenFirstNodeID: new Set() }
+    };
+
+    beforeEach(() => {
+      dataset.cache.seen.clear();
+      dataset.cache.splitWays.clear();
+      dataset.cache.seenFirstNodeID.clear();
+    });
+
+    it('parses a relation element into an osmRelation entity', () => {
+      const xml = new DOMParser().parseFromString(
+        '<relation id="-100">' +
+          '<member type="way" ref="-1" role="outline"/>' +
+          '<member type="way" ref="-2" role="part"/>' +
+          '<tag k="type" v="building"/>' +
+          '<tag k="building" v="yes"/>' +
+        '</relation>', 'text/xml'
+      ).documentElement;
+      const entity = _service._parseEntity(dataset, null, xml);
+      expect(entity).to.not.be.null;
+      expect(entity.id).to.eql('r-100');
+      expect(entity.type).to.eql('relation');
+      expect(entity.tags.type).to.eql('building');
+      expect(entity.members).to.have.length(2);
+      expect(dataset.cache.seen.has('r-100')).to.be.true;
+    });
+
+    it('skips duplicate relation IDs (cache.seen)', () => {
+      const xml = new DOMParser().parseFromString(
+        '<relation id="-100"><tag k="type" v="building"/></relation>', 'text/xml'
+      ).documentElement;
+      const first = _service._parseEntity(dataset, null, xml);
+      const second = _service._parseEntity(dataset, null, xml);
+      expect(first).to.not.be.null;
+      expect(second).to.be.null;
+    });
+  });
+
+
   describe('#_filterPlateauOverlaps', () => {
     // Helper: create an OSM closed way (building) in the graph
     function makeBuilding(graph, wayId, coords) {

--- a/test/unit/actions/rapid_accept_feature.test.js
+++ b/test/unit/actions/rapid_accept_feature.test.js
@@ -80,4 +80,116 @@ describe('actionRapidAcceptFeature', () => {
         const graph = Rapid.actionRapidAcceptFeature(node.id, new Rapid.Graph([node]))(new Rapid.Graph());
         assert.ok(graph.hasEntity(node.id));
     });
+
+
+    // ----------------------------------------------------------------------
+    // Phase 3: building relation cascade
+    // ユーザーが PLATEAU LOD2 の outline / part を click した時、
+    // 関連する type=building relation 全体 (outline + parts + relation) を一括 accept する。
+    // ----------------------------------------------------------------------
+
+    it('accepts the parent type=building relation when accepting a part way', () => {
+        const n1 = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+        const n2 = Rapid.osmNode({ id: 'n2', loc: [0, 1] });
+        const n3 = Rapid.osmNode({ id: 'n3', loc: [1, 1] });
+        const n4 = Rapid.osmNode({ id: 'n4', loc: [1, 0] });
+        const outline = Rapid.osmWay({ id: 'w_outline', nodes: ['n1', 'n2', 'n3', 'n4', 'n1'], tags: { building: 'yes', height: '10' } });
+        const part = Rapid.osmWay({ id: 'w_part', nodes: ['n1', 'n2', 'n3', 'n4', 'n1'], tags: { 'building:part': 'yes', height: '5' } });
+        const relation = Rapid.osmRelation({
+            id: 'r_building',
+            tags: { type: 'building', building: 'yes', height: '10' },
+            members: [
+                { id: outline.id, type: 'way', role: 'outline' },
+                { id: part.id, type: 'way', role: 'part' }
+            ]
+        });
+        const extGraph = new Rapid.Graph([n1, n2, n3, n4, outline, part, relation]);
+
+        // ユーザーが part だけを click したケース
+        const graph = Rapid.actionRapidAcceptFeature(part.id, extGraph)(new Rapid.Graph());
+
+        // relation + outline + part が全部入る
+        assert.ok(graph.hasEntity('r_building'), 'relation not in graph');
+        assert.ok(graph.hasEntity('w_outline'), 'outline not in graph');
+        assert.ok(graph.hasEntity('w_part'), 'part not in graph');
+    });
+
+    it('accepts the parent type=building relation when accepting the outline way', () => {
+        const n1 = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+        const outline = Rapid.osmWay({ id: 'w_outline', nodes: ['n1'], tags: { building: 'yes' } });
+        const part = Rapid.osmWay({ id: 'w_part', nodes: ['n1'], tags: { 'building:part': 'yes' } });
+        const relation = Rapid.osmRelation({
+            id: 'r_building',
+            tags: { type: 'building', building: 'yes' },
+            members: [
+                { id: outline.id, type: 'way', role: 'outline' },
+                { id: part.id, type: 'way', role: 'part' }
+            ]
+        });
+        const extGraph = new Rapid.Graph([n1, outline, part, relation]);
+
+        // outline を click したケース → relation 経由で part も一緒に accept
+        const graph = Rapid.actionRapidAcceptFeature(outline.id, extGraph)(new Rapid.Graph());
+
+        assert.ok(graph.hasEntity('r_building'));
+        assert.ok(graph.hasEntity('w_outline'));
+        assert.ok(graph.hasEntity('w_part'));
+    });
+
+    it('does NOT cascade for ways in non-building relations', () => {
+        const n1 = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+        const way = Rapid.osmWay({ id: 'w', nodes: ['n1'], tags: { highway: 'primary' } });
+        const route = Rapid.osmRelation({
+            id: 'r_route',
+            tags: { type: 'route', route: 'bus' },
+            members: [{ id: way.id, type: 'way', role: '' }]
+        });
+        const extGraph = new Rapid.Graph([n1, way, route]);
+
+        const graph = Rapid.actionRapidAcceptFeature(way.id, extGraph)(new Rapid.Graph());
+
+        // way は accept されるが、type=building ではない relation は cascade されない
+        assert.ok(graph.hasEntity('w'));
+        assert.ok(!graph.hasEntity('r_route'), 'non-building relation should NOT be cascaded');
+    });
+
+    it('processes building relation only once even if multiple members are picked', () => {
+        // 内部 cascade ロジックの再帰防止検証: relation を accept する過程で
+        // 各 member way の acceptWay が呼ばれるが、その都度 relation を再 accept しないこと。
+        const n1 = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+        const outline = Rapid.osmWay({ id: 'w_outline', nodes: ['n1'], tags: { building: 'yes' } });
+        const part1 = Rapid.osmWay({ id: 'w_part1', nodes: ['n1'], tags: { 'building:part': 'yes' } });
+        const part2 = Rapid.osmWay({ id: 'w_part2', nodes: ['n1'], tags: { 'building:part': 'yes' } });
+        const relation = Rapid.osmRelation({
+            id: 'r_building',
+            tags: { type: 'building' },
+            members: [
+                { id: outline.id, type: 'way', role: 'outline' },
+                { id: part1.id, type: 'way', role: 'part' },
+                { id: part2.id, type: 'way', role: 'part' }
+            ]
+        });
+        const extGraph = new Rapid.Graph([n1, outline, part1, part2, relation]);
+
+        // part1 を accept → relation cascade → outline / part1 / part2 全部 accept
+        const graph = Rapid.actionRapidAcceptFeature(part1.id, extGraph)(new Rapid.Graph());
+
+        assert.ok(graph.hasEntity('r_building'));
+        assert.ok(graph.hasEntity('w_outline'));
+        assert.ok(graph.hasEntity('w_part1'));
+        assert.ok(graph.hasEntity('w_part2'));
+        // relation の members は元の3件のまま (重複追加されていない)
+        assert.equal(graph.entity('r_building').members.length, 3);
+    });
+
+    it('accepts a standalone way without cascading when not in any relation', () => {
+        const n1 = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+        const way = Rapid.osmWay({ id: 'w_solo', nodes: ['n1'], tags: { building: 'yes' } });
+        const extGraph = new Rapid.Graph([n1, way]);
+
+        const graph = Rapid.actionRapidAcceptFeature(way.id, extGraph)(new Rapid.Graph());
+
+        // 既存挙動: 単独 way のみ accept
+        assert.ok(graph.hasEntity('w_solo'));
+    });
 });


### PR DESCRIPTION
## Summary

- `MapWithAIService` の XML パースで `<relation>` 要素を取り込むよう拡張
- `rapid_accept_feature` で「`type=building` relation の member な way を accept したら、relation 全体 (outline + 全 parts + relation 自体) を一括 accept」する cascade ロジックを追加
- ユニットテスト 5件 + ブラウザテスト 5件追加

Closes #12

## 背景

`rapid_plateau_api#19` (Phase 2) で API は PLATEAU 元データと同じ `<relation type=building>` 構造を返すようになった。しかし `MapWithAIService` は `<relation>` を捨てていたため Rapid 内部 graph に届かず、ユーザーが LOD2 building の part を `Add This Feature` で追加すると **OSM 側に relation 無しの orphan `building:part` way が作られる** (OSM Simple 3D Buildings 慣習に違反) という不具合があった。

## 変更点

### `modules/services/MapWithAIService.js` (relation 受信)

```javascript
// _parseEntity の type 判定
- if (!['node', 'way'].includes(type)) return null;
+ if (!['node', 'way', 'relation'].includes(type)) return null;
...
+ } else if (type === 'relation') {
+   if (cache.seen.has(entityID)) return null;
+   entity = this._parseRelation(element, entityID);
+   cache.seen.add(entityID);
+ }
```

新規ヘルパー:
- `_getMembers(xml)`: `<member>` から `{id, type, role}` を抽出 (OsmService 流用)
- `_parseRelation(obj, uid)`: `osmRelation` インスタンスを生成

### `modules/actions/rapid_accept_feature.js` (cascade accept)

```javascript
function acceptWay(extWay) {
+   // PLATEAU LOD2: type=building relation の member なら relation 全体を accept
+   var parents = extGraph.parentRelations(extWay);
+   for (var i = 0; i < parents.length; i++) {
+     var parent = parents[i];
+     if (parent.tags?.type === 'building'
+         && !seenRelations[parent.id]
+         && !inProgressRelations[parent.id]) {
+       return acceptRelation(parent);
+     }
+   }
    // 既存ロジック
    ...
}
```

- `acceptRelation` は既存 (Rapid 既存実装) で完成しており、追加実装は不要
- `inProgressRelations` を新設して `way → relation → 各 member acceptWay → 親 relation` の再 cascade を防止
- 既存 `seenRelations` は relation の最後で set されるため、cascade 中 (member 処理中) には未 set 状態が続く点を補完

エッジケース対応:
- relation member の `extEntity` が extGraph に無い場合 (bbox 境界などで partial load) は、member 参照を維持しつつ accept を skip
- 非 `type=building` relation (route 等) は cascade しない (既存挙動を維持)

## 影響範囲

- **PLATEAU データ**: outline / part どちらの way を click しても、relation + outline + 全 parts が一括 accept される
- **他 MapWithAI データセット** (fbRoads, msBuildings, omdFootways, metaSyntheticFootways): relation を含まないため cascade 条件に当たらず、既存挙動そのまま
- **API request**: 変更なし (受信側のみ)

## Test plan

- [x] `npm run test:unit`: 1174 passing (1169 既存 + 5 新規 cascade テスト)
- [x] `npm run test:browser`: 578 passing (568 既存 + 10 新規 parse/relation テスト)
- [x] `npm run lint`: 0 errors
- [ ] ローカル `npm run start` で実 API (高知市 mesh 50332481 の 14 parts 建物) を click → relation + outline + parts が graph に追加されるか確認
- [ ] OSM API 保存ダイアログで relation が含まれるか確認

## スコープ外 (将来 Phase 4)

- **relation 単位の conflation**: 現状 way 単位。outline が OSM 既存建物と衝突した時、parts もまとめて隠す高度化
- **視覚的ハイライト**: relation メンバーを選択した際の Pixi rendering 強化
- **部分 accept トグル**: 「relation 全体ではなく、この parts だけ追加」の UX

## 関連

- `nyampire/rapid_plateau_api#16` (Phase 1: DB)
- `nyampire/rapid_plateau_api#18` (Phase 2: API)
- 本 PR (Phase 3: Rapid client)
