### PR TITLE
Phase 4-A: Relation-aware conflation for PLATEAU LOD2 buildings

### DIFF
--- a/modules/services/MapWithAIService.js
+++ b/modules/services/MapWithAIService.js
@@ -394,6 +394,12 @@ export class MapWithAIService extends AbstractSystem {
    * Client-side conflation for Plateau buildings.
    * Filters out Plateau entities that overlap with existing OSM buildings,
    * using the same bbox + Polyclip polygon intersection approach as OvertureService.
+   *
+   * Phase 4-A: PLATEAU LOD2 building は outline + parts + type=building relation で
+   * 1つの semantic 単位を成すため、relation のメンバー way は **outline の判定結果に従う**。
+   * outline と各 parts が個別に reject される結果として「親 outline が消えて parts だけ宙に浮く」
+   * 等のジオメトリ不整合を防ぐ。
+   *
    * @param   {Array}  entities - Plateau entities from the tree
    * @param   {Graph}  plateauGraph - The Plateau dataset graph (for resolving node coords)
    * @return  {Array}  Filtered entities (non-overlapping only)
@@ -441,62 +447,129 @@ export class MapWithAIService extends AbstractSystem {
     // If no OSM buildings in view, skip conflation
     if (osmBuildingData.length === 0) return entities;
 
+    // Phase 4-A: way_id → building relation のマップを構築。
+    // 並行して relation_id → outline way_id を記録 (outline で代表判定するため)。
+    const wayToBuildingRelation = new Map();        // way_id → relation entity
+    const buildingRelationOutline = new Map();      // relation_id → outline way_id (or undefined)
+    for (const e of entities) {
+      if (e.type !== 'relation') continue;
+      if (e.tags?.type !== 'building') continue;
+      let outlineWayId;
+      for (const m of e.members ?? []) {
+        if (m.type !== 'way') continue;
+        if (!wayToBuildingRelation.has(m.id)) {
+          wayToBuildingRelation.set(m.id, e);
+        }
+        if (m.role === 'outline' && outlineWayId === undefined) {
+          outlineWayId = m.id;
+        }
+      }
+      buildingRelationOutline.set(e.id, outlineWayId);
+    }
+
+    // relation 単位の判定結果キャッシュ (このバッチ内のみ)。
+    // outline の overlap 判定を1回行い、relation の全 member で再利用。
+    const relationOverlapDecision = new Map();  // relation_id → true (overlap) / false (no overlap) / null (unknown)
+
+    const evalRelationOverlap = (relation) => {
+      if (relationOverlapDecision.has(relation.id)) {
+        return relationOverlapDecision.get(relation.id);
+      }
+      const outlineWayId = buildingRelationOutline.get(relation.id);
+      if (!outlineWayId) {
+        relationOverlapDecision.set(relation.id, null);
+        return null;
+      }
+      const outlineWay = plateauGraph.hasEntity(outlineWayId);
+      if (!outlineWay) {
+        relationOverlapDecision.set(relation.id, null);
+        return null;
+      }
+      const decision = this._checkWayOverlapsOsmBuildings(outlineWay, plateauGraph, osmBuildingData);
+      // decision: true = overlap, false = no overlap, null = couldn't evaluate (open way etc.)
+      relationOverlapDecision.set(relation.id, decision);
+      return decision;
+    };
+
     // 3. Filter each Plateau entity against OSM buildings
     return entities.filter(entity => {
-      if (entity.type !== 'way') return true;  // Keep nodes (needed for way coordinate resolution)
+      if (entity.type === 'node') return true;  // Keep nodes (needed for way coordinate resolution)
+      if (entity.type === 'relation') return true;  // relations 自体は filter 対象外 (member way の判定で実質決まる)
+      if (entity.type !== 'way') return true;
 
-      // Cache hit - already determined
+      // Cache hit - already determined (across batches via _plateauConflationCache)
       if (cache.rejected.has(entity.id)) return false;
       if (cache.checked.has(entity.id)) return true;
 
-      try {
-        if (!entity.isClosed()) {
+      // Phase 4-A: building relation の member なら relation の判定結果を採用
+      const parentRel = wayToBuildingRelation.get(entity.id);
+      if (parentRel) {
+        const decision = evalRelationOverlap(parentRel);
+        if (decision === true) {
+          cache.rejected.add(entity.id);
+          return false;
+        }
+        if (decision === false) {
           cache.checked.add(entity.id);
           return true;
         }
-
-        // Get Plateau building polygon coordinates
-        const coords = entity.nodes.map(nodeID => plateauGraph.entity(nodeID).loc);
-        if (coords.length < 4) {
-          cache.checked.add(entity.id);
-          return true;
-        }
-
-        // Compute bounding box for fast pre-filtering
-        let oMinX = Infinity, oMinY = Infinity, oMaxX = -Infinity, oMaxY = -Infinity;
-        for (const c of coords) {
-          if (c[0] < oMinX) oMinX = c[0];
-          if (c[0] > oMaxX) oMaxX = c[0];
-          if (c[1] < oMinY) oMinY = c[1];
-          if (c[1] > oMaxY) oMaxY = c[1];
-        }
-
-        // Check against each OSM building
-        for (const osm of osmBuildingData) {
-          const ob = osm.bbox;
-          // Fast bounding box rejection
-          if (oMaxX < ob.minX || oMinX > ob.maxX || oMaxY < ob.minY || oMinY > ob.maxY) {
-            continue;
-          }
-          // Full polygon intersection test
-          try {
-            const intersection = Polyclip.intersection([coords], osm.coords);
-            if (intersection && intersection.length > 0) {
-              cache.rejected.add(entity.id);
-              return false;
-            }
-          } catch (e) {
-            continue;  // Polyclip can throw on invalid geometries
-          }
-        }
-
-        cache.checked.add(entity.id);
-        return true;
-      } catch (e) {
-        cache.checked.add(entity.id);
-        return true;
+        // decision === null → relation 判定不能、個別 way 判定にフォールバック
       }
+
+      // 個別 way 判定 (relation 非 member、または relation 判定不能のフォールバック)
+      const decision = this._checkWayOverlapsOsmBuildings(entity, plateauGraph, osmBuildingData);
+      if (decision === true) {
+        cache.rejected.add(entity.id);
+        return false;
+      }
+      // decision === false または null → pass として扱う (open way 等)
+      cache.checked.add(entity.id);
+      return true;
     });
+  }
+
+
+  /**
+   * _checkWayOverlapsOsmBuildings
+   * 1つの Plateau way が OSM 建物群と重複するか判定する純粋ロジック。
+   * `_filterPlateauOverlaps` から呼ばれ、個別判定と relation outline 代表判定で再利用される。
+   *
+   * @return {boolean | null} true = overlap, false = no overlap, null = couldn't evaluate (open way / invalid coords)
+   */
+  _checkWayOverlapsOsmBuildings(way, plateauGraph, osmBuildingData) {
+    try {
+      if (!way.isClosed()) return null;
+
+      const coords = way.nodes.map(nodeID => plateauGraph.entity(nodeID).loc);
+      if (coords.length < 4) return null;
+
+      let oMinX = Infinity, oMinY = Infinity, oMaxX = -Infinity, oMaxY = -Infinity;
+      for (const c of coords) {
+        if (c[0] < oMinX) oMinX = c[0];
+        if (c[0] > oMaxX) oMaxX = c[0];
+        if (c[1] < oMinY) oMinY = c[1];
+        if (c[1] > oMaxY) oMaxY = c[1];
+      }
+
+      for (const osm of osmBuildingData) {
+        const ob = osm.bbox;
+        if (oMaxX < ob.minX || oMinX > ob.maxX || oMaxY < ob.minY || oMinY > ob.maxY) {
+          continue;
+        }
+        try {
+          const intersection = Polyclip.intersection([coords], osm.coords);
+          if (intersection && intersection.length > 0) {
+            return true;
+          }
+        } catch (e) {
+          continue;  // Polyclip can throw on invalid geometries
+        }
+      }
+
+      return false;
+    } catch (e) {
+      return null;
+    }
   }
 
 

--- a/test/browser/services/MapWithAIService.test.js
+++ b/test/browser/services/MapWithAIService.test.js
@@ -368,6 +368,202 @@ describe('MapWithAIService', () => {
       const result = _service._filterPlateauOverlaps([openWay], new Rapid.Graph());
       expect(result).to.have.lengthOf(1);
     });
+
+
+    // ----------------------------------------------------------------------
+    // Phase 4-A: relation-aware conflation
+    // PLATEAU LOD2 building (outline + parts + type=building relation) を
+    // relation 単位で表示 / 非表示判定する
+    // ----------------------------------------------------------------------
+
+    function makeBuildingRelationWithParts(plateauGraph, outlineId, partIds, outlineCoords, partCoordsArr) {
+      // outline way
+      let g = plateauGraph;
+      const outRes = makePlateauWay(g, outlineId, outlineCoords);
+      g = outRes.graph;
+      const outline = outRes.way;
+      // parts
+      const parts = [];
+      for (let i = 0; i < partIds.length; i++) {
+        const pRes = makePlateauWay(g, partIds[i], partCoordsArr[i]);
+        g = pRes.graph;
+        parts.push(pRes.way);
+      }
+      // relation
+      const members = [{ id: outline.id, type: 'way', role: 'outline' }];
+      for (const p of parts) members.push({ id: p.id, type: 'way', role: 'part' });
+      const relation = Rapid.osmRelation({
+        id: 'r_building_' + outlineId,
+        tags: { type: 'building', building: 'yes' },
+        members: members,
+      });
+      g = g.replace(relation);
+      return { graph: g, outline, parts, relation };
+    }
+
+    it('rejects all relation members when outline overlaps OSM building', () => {
+      // OSM building at (0,0)-(1,1)
+      let osmGraph = new Rapid.Graph();
+      const osmRes = makeBuilding(osmGraph, 'osmB1', [[0,0], [1,0], [1,1], [0,1]]);
+      _service.context.systems.editor._graph = osmRes.graph;
+      _service.context.systems.editor._entities = [osmRes.way];
+
+      // Plateau relation: outline overlaps OSM, parts inside outline
+      let plateauGraph = new Rapid.Graph();
+      const rel = makeBuildingRelationWithParts(
+        plateauGraph, 'pOutline', ['pPart1', 'pPart2'],
+        [[0.5,0.5], [1.5,0.5], [1.5,1.5], [0.5,1.5]],  // outline overlaps
+        [
+          [[0.6,0.6], [0.9,0.6], [0.9,0.9], [0.6,0.9]],  // part inside outline (overlaps OSM)
+          [[1.1,1.1], [1.4,1.1], [1.4,1.4], [1.1,1.4]],  // part outside OSM bbox (would normally pass)
+        ]
+      );
+      plateauGraph = rel.graph;
+
+      const entities = [rel.outline, rel.parts[0], rel.parts[1], rel.relation];
+      const result = _service._filterPlateauOverlaps(entities, plateauGraph);
+
+      // outline + parts は relation のおかげで一括 reject される
+      const wayResults = result.filter(e => e.type === 'way');
+      expect(wayResults).to.have.lengthOf(0);
+      // relation 自体は filter 対象外なので残る
+      const relResults = result.filter(e => e.type === 'relation');
+      expect(relResults).to.have.lengthOf(1);
+    });
+
+    it('keeps all relation members when outline does NOT overlap OSM building', () => {
+      // OSM building at (0,0)-(1,1)
+      let osmGraph = new Rapid.Graph();
+      const osmRes = makeBuilding(osmGraph, 'osmB1', [[0,0], [1,0], [1,1], [0,1]]);
+      _service.context.systems.editor._graph = osmRes.graph;
+      _service.context.systems.editor._entities = [osmRes.way];
+
+      // Plateau relation: outline at (10,10)-(11,11), away from OSM building
+      let plateauGraph = new Rapid.Graph();
+      const rel = makeBuildingRelationWithParts(
+        plateauGraph, 'pOutline2', ['pPart3'],
+        [[10,10], [11,10], [11,11], [10,11]],
+        [[[10.2,10.2], [10.8,10.2], [10.8,10.8], [10.2,10.8]]],
+      );
+      plateauGraph = rel.graph;
+
+      const entities = [rel.outline, rel.parts[0], rel.relation];
+      const result = _service._filterPlateauOverlaps(entities, plateauGraph);
+
+      const wayResults = result.filter(e => e.type === 'way');
+      expect(wayResults).to.have.lengthOf(2);  // outline + 1 part 両方残る
+    });
+
+    it('falls back to per-way check when relation has no outline member', () => {
+      // OSM building at (0,0)-(1,1)
+      let osmGraph = new Rapid.Graph();
+      const osmRes = makeBuilding(osmGraph, 'osmB1', [[0,0], [1,0], [1,1], [0,1]]);
+      _service.context.systems.editor._graph = osmRes.graph;
+      _service.context.systems.editor._entities = [osmRes.way];
+
+      // relation だが outline メンバー無し、parts のみ
+      let g = new Rapid.Graph();
+      const part1 = makePlateauWay(g, 'pPartA', [[0.5,0.5], [1.5,0.5], [1.5,1.5], [0.5,1.5]]); // overlaps
+      g = part1.graph;
+      const part2 = makePlateauWay(g, 'pPartB', [[10,10], [11,10], [11,11], [10,11]]); // no overlap
+      g = part2.graph;
+      const relation = Rapid.osmRelation({
+        id: 'r_no_outline',
+        tags: { type: 'building' },
+        members: [
+          { id: part1.way.id, type: 'way', role: 'part' },
+          { id: part2.way.id, type: 'way', role: 'part' },
+        ],
+      });
+      g = g.replace(relation);
+
+      const entities = [part1.way, part2.way, relation];
+      const result = _service._filterPlateauOverlaps(entities, g);
+
+      // outline 無しなので個別判定にフォールバック: pPartA は reject、pPartB は pass
+      const wayIds = result.filter(e => e.type === 'way').map(e => e.id);
+      expect(wayIds).to.not.include('pPartA');
+      expect(wayIds).to.include('pPartB');
+    });
+
+    it('non-building relation members are evaluated per-way', () => {
+      // OSM building at (0,0)-(1,1)
+      let osmGraph = new Rapid.Graph();
+      const osmRes = makeBuilding(osmGraph, 'osmB1', [[0,0], [1,0], [1,1], [0,1]]);
+      _service.context.systems.editor._graph = osmRes.graph;
+      _service.context.systems.editor._entities = [osmRes.way];
+
+      // 非 building relation (例: type=route) の member way → 個別判定
+      let g = new Rapid.Graph();
+      const w1 = makePlateauWay(g, 'pRouteWay', [[0.5,0.5], [1.5,0.5], [1.5,1.5], [0.5,1.5]]);
+      g = w1.graph;
+      const routeRel = Rapid.osmRelation({
+        id: 'r_route',
+        tags: { type: 'route', route: 'bus' },
+        members: [{ id: w1.way.id, type: 'way', role: '' }],
+      });
+      g = g.replace(routeRel);
+
+      const result = _service._filterPlateauOverlaps([w1.way, routeRel], g);
+      // route relation 経由の cascade は無し、個別 way 判定で reject
+      const wayResults = result.filter(e => e.type === 'way');
+      expect(wayResults).to.have.lengthOf(0);
+    });
+  });
+
+
+  // ----------------------------------------------------------------------
+  // _checkWayOverlapsOsmBuildings (pure helper)
+  // ----------------------------------------------------------------------
+
+  describe('#_checkWayOverlapsOsmBuildings', () => {
+    function makePlateauWay(graph, wayId, coords) {
+      const nodeIds = [];
+      for (let i = 0; i < coords.length; i++) {
+        const nodeId = wayId + '-n' + i;
+        nodeIds.push(nodeId);
+        graph = graph.replace(Rapid.osmNode({ id: nodeId, loc: coords[i] }));
+      }
+      nodeIds.push(nodeIds[0]);
+      const way = Rapid.osmWay({ id: wayId, nodes: nodeIds, tags: { building: 'yes' } });
+      graph = graph.replace(way);
+      return { graph, way };
+    }
+
+    function makeOsmBuildingData(coords) {
+      const closed = coords.concat([coords[0]]);
+      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      for (const c of closed) {
+        if (c[0] < minX) minX = c[0];
+        if (c[0] > maxX) maxX = c[0];
+        if (c[1] < minY) minY = c[1];
+        if (c[1] > maxY) maxY = c[1];
+      }
+      return [{ coords: [closed], bbox: { minX, minY, maxX, maxY } }];
+    }
+
+    it('returns true when way overlaps OSM building', () => {
+      const plateauResult = makePlateauWay(new Rapid.Graph(),
+        'pW', [[0.5,0.5], [1.5,0.5], [1.5,1.5], [0.5,1.5]]);
+      const osmData = makeOsmBuildingData([[0,0], [1,0], [1,1], [0,1]]);
+      const result = _service._checkWayOverlapsOsmBuildings(plateauResult.way, plateauResult.graph, osmData);
+      expect(result).to.be.true;
+    });
+
+    it('returns false when way does NOT overlap OSM building', () => {
+      const plateauResult = makePlateauWay(new Rapid.Graph(),
+        'pW', [[10,10], [11,10], [11,11], [10,11]]);
+      const osmData = makeOsmBuildingData([[0,0], [1,0], [1,1], [0,1]]);
+      const result = _service._checkWayOverlapsOsmBuildings(plateauResult.way, plateauResult.graph, osmData);
+      expect(result).to.be.false;
+    });
+
+    it('returns null for open ways', () => {
+      const openWay = Rapid.osmWay({ id: 'pOpen', nodes: ['a', 'b', 'c'] });
+      const osmData = makeOsmBuildingData([[0,0], [1,0], [1,1], [0,1]]);
+      const result = _service._checkWayOverlapsOsmBuildings(openWay, new Rapid.Graph(), osmData);
+      expect(result).to.be.null;
+    });
   });
 
 });


### PR DESCRIPTION
## Summary

- `_filterPlateauOverlaps` を **relation 単位** で判定するよう拡張
- type=building relation の outline で1回 overlap 判定 → 全 member (outline + parts) に同じ結果を適用
- 共通ロジックを `_checkWayOverlapsOsmBuildings` ヘルパーに切り出し
- 関連テスト 7 件追加

Closes #14

## 背景

Phase 3 で relation を Rapid の graph に取り込み、Phase 4-A では conflation を relation 単位に揃える。

旧コードは way 単位の polygon 交差判定。PLATEAU LOD2 building は outline + parts + relation で 1 semantic 単位を成すため、way 単位判定だと:
- outline が OSM 既存建物と重複 → outline reject、parts は判定次第で残る → **親 outline が消えて parts だけ宙に浮く** 表示崩れ
- 逆も成立 (outline pass、ある part だけ OSM と重複して reject → 不完全 building)

## 変更点

### `modules/services/MapWithAIService.js`

#### `_filterPlateauOverlaps` 改修

```javascript
// way_id → building relation と relation_id → outline way_id のマップ構築
const wayToBuildingRelation = new Map();
const buildingRelationOutline = new Map();
for (const e of entities) {
    if (e.type !== 'relation' || e.tags?.type !== 'building') continue;
    let outlineWayId;
    for (const m of e.members ?? []) {
        if (m.type !== 'way') continue;
        wayToBuildingRelation.set(m.id, e);
        if (m.role === 'outline' && outlineWayId === undefined) {
            outlineWayId = m.id;
        }
    }
    buildingRelationOutline.set(e.id, outlineWayId);
}

// relation 単位の判定キャッシュ (per-batch)
const relationOverlapDecision = new Map();
const evalRelationOverlap = (relation) => {
    // outline で 1回判定し、relation の全 member で再利用
    ...
};

// filter ループで relation 結果を優先採用
return entities.filter(entity => {
    ...
    const parentRel = wayToBuildingRelation.get(entity.id);
    if (parentRel) {
        const decision = evalRelationOverlap(parentRel);
        if (decision === true) { cache.rejected.add(entity.id); return false; }
        if (decision === false) { cache.checked.add(entity.id); return true; }
        // decision === null → 個別 way 判定にフォールバック
    }
    // 個別 way 判定
    ...
});
```

#### `_checkWayOverlapsOsmBuildings` 新規ヘルパー

per-way 判定ロジックを純粋関数に切り出し:
- 戻り値 tri-state: `true` (overlap), `false` (no overlap), `null` (評価不能 — open way 等)
- outline 代表判定と個別 way 判定の両方で再利用

### エッジケース

| ケース | 挙動 |
|---|---|
| relation に role=outline メンバー無し | 個別 way 判定にフォールバック (テスト済) |
| outline way が plateauGraph に解決できない (bbox 境界) | 個別 way 判定にフォールバック |
| 1つの way が複数 building relation に所属 (極稀) | 最初に見つかった relation の結果を採用 |
| 非 building relation (route 等) | 既存 per-way 挙動を維持 (テスト済) |
| relation 非 member な way | 既存 per-way 挙動を維持 |
| relation 自体 | filter 通過 (visible 判定は member 側で行われる) |

## テスト

`test/browser/services/MapWithAIService.test.js` に追加:

**#_filterPlateauOverlaps (relation-aware)** — 4件
- outline が OSM 既存建物と重複 → outline + 全 parts が一括 reject
- outline が重複しない → outline + 全 parts が一括 pass
- relation に outline 無し → 個別 way 判定にフォールバック
- 非 building relation (type=route) member → 個別 way 判定

**#_checkWayOverlapsOsmBuildings (pure helper)** — 3件
- 重複 → true 返す
- 非重複 → false 返す
- 開放 way → null 返す

## Test plan

- [x] `npm run test:unit`: 1174 passing
- [x] `npm run test:browser`: 585 passing (前回 578 + 新規 7)
- [x] `npm run lint`: 0 errors
- [ ] ローカル `npm run start` で実 API (高知市 mesh 50332481 area) の OSM 既存建物と PLATEAU LOD2 building の重複ケース挙動確認

## 関連

- `nyampire/Rapid#12` (Phase 3) ✅ Closed
- 本 PR (Phase 4-A)
- 後続 Phase 4-B (視覚ハイライト), Phase 4-C (部分 accept トグル)

## スコープ外 (Phase 4-B, 4-C)

- multi-part building の視覚的ハイライト (inspector + Pixi)
- 部分 accept トグル (cascade skip option)
