### PR TITLE
Phase 4-B-1: Inspector hint and 'Add Entire Building' label for multi-section buildings

### DIFF
--- a/css/80_app_fb.css
+++ b/css/80_app_fb.css
@@ -414,6 +414,19 @@ button.overture-inspector-close:hover {
   border-radius: 5px;
 }
 
+/* Phase 4-B-1: multi-section building 情報行 (PLATEAU LOD2 等) */
+.rapid-inspector-multi-section-building-info {
+  margin: -6px 10px 8px;
+  padding: 6px 8px;
+  font-size: 12px;
+  font-style: italic;
+  color: #555;
+  background: rgba(102, 187, 106, 0.15);  /* Plateau 緑の薄い背景 */
+  border-left: 3px solid #66BB6A;
+  border-radius: 3px;
+  text-align: left;
+}
+
 .rapid-inspector-choice {
   display: flex;
   flex: 0 0 0px;

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1115,6 +1115,13 @@ en:
       tooltip: Add this feature to the map to begin editing.
       disabled: To help improve OSM data quality, we only allow {n} AI features to be added in each mapping session. Please try to fix issues on your edits so far. You will be able to add more AI features after saving.
       disabled_flash: To help improve OSM data quality, we only allow {n} AI Features to be added in each mapping session.
+    option_accept_entire_building:
+      label: Add Entire Building
+      description: This way is part of a multi-section building (outline + parts). Selecting this will add the outline, every part, and the relation together so the OSM structure stays consistent.
+      tooltip: Add the entire building (outline and all parts) to the map.
+    multi_section_building_info:
+      one: This way is part of a multi-section building ({n} part).
+      other: This way is part of a multi-section building ({n} parts).
     option_ignore:
       label: Ignore This Feature
       description: Ignoring this feature helps us improve our machine learning. If you are unsure whether or not this is an accurate feature, feel free to leave it as is, nothing will be saved or lost. 👍

--- a/data/l10n/core.en.json
+++ b/data/l10n/core.en.json
@@ -1394,6 +1394,15 @@
         "disabled": "To help improve OSM data quality, we only allow {n} AI features to be added in each mapping session. Please try to fix issues on your edits so far. You will be able to add more AI features after saving.",
         "disabled_flash": "To help improve OSM data quality, we only allow {n} AI Features to be added in each mapping session."
       },
+      "option_accept_entire_building": {
+        "label": "Add Entire Building",
+        "description": "This way is part of a multi-section building (outline + parts). Selecting this will add the outline, every part, and the relation together so the OSM structure stays consistent.",
+        "tooltip": "Add the entire building (outline and all parts) to the map."
+      },
+      "multi_section_building_info": {
+        "one": "This way is part of a multi-section building ({n} part).",
+        "other": "This way is part of a multi-section building ({n} parts)."
+      },
       "option_ignore": {
         "label": "Ignore This Feature",
         "description": "Ignoring this feature helps us improve our machine learning. If you are unsure whether or not this is an accurate feature, feel free to leave it as is, nothing will be saved or lost. 👍",

--- a/modules/ui/UiRapidInspector.js
+++ b/modules/ui/UiRapidInspector.js
@@ -7,6 +7,7 @@ import { uiFlash } from './flash.js';
 //import { uiRapidFirstEditDialog } from './rapid_first_edit_dialog.js';
 import { uiTooltip } from './tooltip.js';
 import { utilKeybinding } from '../util/keybinding.js';
+import { utilBuildingRelationInfo } from '../util/building_relation.js';
 
 const ACCEPT_FEATURES_LIMIT = 50;
 
@@ -394,6 +395,23 @@ export class UiRapidInspector {
 
 
   /**
+   * _getBuildingRelationInfo
+   * Phase 4-B-1: 現在選択中の datum が `type=building` relation のメンバー way である場合、
+   * その relation の情報 (outline / parts のカウント) を返す。それ以外は null。
+   *
+   * @return {{relation: osmRelation, outlineCount: number, partCount: number} | null}
+   */
+  _getBuildingRelationInfo() {
+    const datum = this.datum;
+    if (!datum) return null;
+    const service = this.context.services[datum.__service__];
+    if (!service || typeof service.graph !== 'function') return null;
+    const graph = service.graph(datum.__datasetid__);
+    return utilBuildingRelationInfo(datum, graph);
+  }
+
+
+  /**
    * renderChoices
    * Renders the 'rapid-inspector-choices' section
    * @param {d3-selection} $selection - A d3-selection to a HTMLElement that this content should render itself into
@@ -402,12 +420,21 @@ export class UiRapidInspector {
     const context = this.context;
     const l10n = context.systems.l10n;
 
+    // Phase 4-B-1: building relation member の場合は label / description を切り替え
+    const buildingInfo = this._getBuildingRelationInfo();
+    const acceptLabelStringID = buildingInfo
+      ? 'rapid_inspector.option_accept_entire_building.label'
+      : 'rapid_inspector.option_accept.label';
+    const acceptReferenceStringID = buildingInfo
+      ? 'rapid_inspector.option_accept_entire_building.description'
+      : 'rapid_inspector.option_accept.description';
+
     const choiceData = [
       {
         key: 'accept',
         iconName: '#rapid-icon-rapid-plus-circle',
-        labelStringID: 'rapid_inspector.option_accept.label',
-        referenceStringID: 'rapid_inspector.option_accept.description',
+        labelStringID: acceptLabelStringID,
+        referenceStringID: acceptReferenceStringID,
         tooltip: this.AcceptTooltip,
         onClick: this.acceptFeature
       }, {
@@ -432,6 +459,11 @@ export class UiRapidInspector {
       .append('p')
       .attr('class', 'rapid-inspector-prompt');
 
+    // Phase 4-B-1: multi-section building info row (常時 DOM に存在させ、不要時は非表示)
+    $$choices
+      .append('p')
+      .attr('class', 'rapid-inspector-multi-section-building-info');
+
     $$choices.selectAll('.rapid-inspector-choice')
       .data(choiceData, d => d.key)
       .enter()
@@ -444,7 +476,22 @@ export class UiRapidInspector {
     $choices.selectAll('.rapid-inspector-prompt')
       .text(l10n.t('rapid_inspector.prompt'));
 
+    // multi-section building 情報行: 該当時のみ表示
+    const $multiInfo = $choices.selectAll('.rapid-inspector-multi-section-building-info');
+    if (buildingInfo) {
+      const partCount = buildingInfo.partCount;
+      $multiInfo
+        .style('display', null)
+        .text(l10n.t('rapid_inspector.multi_section_building_info', { n: partCount }));
+    } else {
+      $multiInfo
+        .style('display', 'none')
+        .text('');
+    }
+
+    // choices の labelStringID 等が building 文脈で切り替わるよう、毎回データを更新
     $choices.selectAll('.rapid-inspector-choice')
+      .data(choiceData, d => d.key)
       .each(this.renderChoice);
   }
 

--- a/modules/util/building_relation.js
+++ b/modules/util/building_relation.js
@@ -1,0 +1,34 @@
+/**
+ * utilBuildingRelationInfo
+ *
+ * 指定 entity が `type=building` relation (Simple 3D Buildings / PLATEAU LOD2 の構造) の
+ * メンバー way である場合に、その relation 情報を返す。それ以外は null。
+ *
+ * UiRapidInspector や conflation ロジックから、UI 表示 / 動作判定の両方で使用。
+ *
+ * @param  {Object|null}  entity - osmEntity (typically a way)
+ * @param  {Graph|null}   graph  - 該当 entity の含まれる Graph (parentRelations を提供)
+ * @return {{relation: osmRelation, outlineCount: number, partCount: number} | null}
+ */
+export function utilBuildingRelationInfo(entity, graph) {
+  if (!entity || entity.type !== 'way') return null;
+  if (!graph || typeof graph.parentRelations !== 'function') return null;
+
+  let parents;
+  try {
+    parents = graph.parentRelations(entity);
+  } catch (e) {
+    return null;
+  }
+
+  const relation = parents.find(r => r.tags && r.tags.type === 'building');
+  if (!relation) return null;
+
+  let outlineCount = 0;
+  let partCount = 0;
+  for (const m of relation.members || []) {
+    if (m.role === 'outline') outlineCount++;
+    else if (m.role === 'part') partCount++;
+  }
+  return { relation, outlineCount, partCount };
+}

--- a/modules/util/index.js
+++ b/modules/util/index.js
@@ -14,3 +14,4 @@ export { utilSetDimensions } from './dimensions.js';
 export { utilSetTransform } from './util.js';
 export { utilTotalExtent } from './util.js';
 export { utilTriggerEvent } from './trigger_event.js';
+export { utilBuildingRelationInfo } from './building_relation.js';

--- a/test/unit/util/building_relation.test.js
+++ b/test/unit/util/building_relation.test.js
@@ -1,0 +1,95 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import * as Rapid from '../../../modules/headless.js';
+
+describe('utilBuildingRelationInfo', () => {
+  it('returns null when entity is not a way', () => {
+    const node = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+    const graph = new Rapid.Graph([node]);
+    const info = Rapid.utilBuildingRelationInfo(node, graph);
+    assert.equal(info, null);
+  });
+
+  it('returns null when entity is null/undefined', () => {
+    const graph = new Rapid.Graph();
+    assert.equal(Rapid.utilBuildingRelationInfo(null, graph), null);
+    assert.equal(Rapid.utilBuildingRelationInfo(undefined, graph), null);
+  });
+
+  it('returns null when graph is missing or lacks parentRelations', () => {
+    const way = Rapid.osmWay({ id: 'w1', nodes: [] });
+    assert.equal(Rapid.utilBuildingRelationInfo(way, null), null);
+    assert.equal(Rapid.utilBuildingRelationInfo(way, {}), null);
+  });
+
+  it('returns null when way has no parent type=building relation', () => {
+    const way = Rapid.osmWay({ id: 'w1', nodes: [] });
+    const graph = new Rapid.Graph([way]);
+    assert.equal(Rapid.utilBuildingRelationInfo(way, graph), null);
+  });
+
+  it('returns null when parent relation is not type=building (e.g., route)', () => {
+    const way = Rapid.osmWay({ id: 'w1', nodes: [] });
+    const route = Rapid.osmRelation({
+      id: 'r1',
+      tags: { type: 'route', route: 'bus' },
+      members: [{ id: way.id, type: 'way', role: '' }],
+    });
+    const graph = new Rapid.Graph([way, route]);
+    assert.equal(Rapid.utilBuildingRelationInfo(way, graph), null);
+  });
+
+  it('returns relation info with outline/part counts', () => {
+    const outline = Rapid.osmWay({ id: 'w_outline', nodes: [], tags: { building: 'yes' } });
+    const part1 = Rapid.osmWay({ id: 'w_part1', nodes: [], tags: { 'building:part': 'yes' } });
+    const part2 = Rapid.osmWay({ id: 'w_part2', nodes: [], tags: { 'building:part': 'yes' } });
+    const relation = Rapid.osmRelation({
+      id: 'r_building',
+      tags: { type: 'building', building: 'yes' },
+      members: [
+        { id: outline.id, type: 'way', role: 'outline' },
+        { id: part1.id, type: 'way', role: 'part' },
+        { id: part2.id, type: 'way', role: 'part' },
+      ],
+    });
+    const graph = new Rapid.Graph([outline, part1, part2, relation]);
+
+    // どの member way から問い合わせても同じ relation を返す
+    const fromOutline = Rapid.utilBuildingRelationInfo(outline, graph);
+    assert.equal(fromOutline.relation.id, 'r_building');
+    assert.equal(fromOutline.outlineCount, 1);
+    assert.equal(fromOutline.partCount, 2);
+
+    const fromPart = Rapid.utilBuildingRelationInfo(part1, graph);
+    assert.equal(fromPart.relation.id, 'r_building');
+    assert.equal(fromPart.outlineCount, 1);
+    assert.equal(fromPart.partCount, 2);
+  });
+
+  it('counts only outline/part roles; ignores other roles', () => {
+    const outline = Rapid.osmWay({ id: 'w_outline', nodes: [] });
+    const part = Rapid.osmWay({ id: 'w_part', nodes: [] });
+    const entrance = Rapid.osmNode({ id: 'n_entrance', loc: [0, 0] });
+    const relation = Rapid.osmRelation({
+      id: 'r_building',
+      tags: { type: 'building' },
+      members: [
+        { id: outline.id, type: 'way', role: 'outline' },
+        { id: part.id, type: 'way', role: 'part' },
+        { id: entrance.id, type: 'node', role: 'entrance' },
+      ],
+    });
+    const graph = new Rapid.Graph([outline, part, entrance, relation]);
+    const info = Rapid.utilBuildingRelationInfo(outline, graph);
+    assert.equal(info.outlineCount, 1);
+    assert.equal(info.partCount, 1);  // entrance ロールはカウントされない
+  });
+
+  it('returns null when graph.parentRelations throws', () => {
+    const way = Rapid.osmWay({ id: 'w1', nodes: [] });
+    const brokenGraph = {
+      parentRelations() { throw new Error('boom'); }
+    };
+    assert.equal(Rapid.utilBuildingRelationInfo(way, brokenGraph), null);
+  });
+});


### PR DESCRIPTION
## Summary

- PLATEAU LOD2 multi-section building の outline / part を Inspector で選択した時、`Add This Feature` ボタンのラベルを **`Add Entire Building`** に動的切り替え
- prompt 直下に「This way is part of a multi-section building (N parts).」の情報行を追加表示
- `utilBuildingRelationInfo` 共通 helper を `modules/util/building_relation.js` に新設
- ユニットテスト 8 件追加

Closes #16

## 背景

Phase 3 で `Add This Feature` クリック時に `type=building` relation 全体を cascade accept するようにしたが、ボタン label は単数 way を示唆したまま。Phase 4-A で conflation を relation 単位に揃えた後、最後の UI 表現が残っていた。本 PR で「何が追加されるか」を Inspector 上で明示する。

## 変更点

### `modules/util/building_relation.js` (新規)

純粋関数 `utilBuildingRelationInfo(entity, graph)`:
- entity が way かつ親 relation の `tags.type === 'building'` を持つ場合、`{relation, outlineCount, partCount}` を返す
- それ以外 (node、null、非 building relation、graph 例外) は null

将来 Phase 4-B-2 (Pixi 視覚化) や Phase 4-C (部分 accept) からも再利用予定。

### `modules/ui/UiRapidInspector.js`

`_getBuildingRelationInfo()` で context.services + datasetID から graph 解決、helper にデリゲート。

`renderChoices` で:
- helper の戻り値が非 null なら、Accept choice の `labelStringID` を `option_accept_entire_building.label` に切り替え
- 「This way is part of a multi-section building (N parts).」の情報 `<p>` を表示 (該当時のみ)

### i18n (`data/core.yaml`)

```yaml
option_accept_entire_building:
  label: Add Entire Building
  description: This way is part of a multi-section building (outline + parts). Selecting this will add the outline, every part, and the relation together so the OSM structure stays consistent.
  tooltip: Add the entire building (outline and all parts) to the map.
multi_section_building_info:
  one: This way is part of a multi-section building ({n} part).
  other: This way is part of a multi-section building ({n} parts).
```

### CSS (`css/80_app_fb.css`)

`.rapid-inspector-multi-section-building-info`: Plateau 緑系の薄背景 + 左 border でアクセント、italic small text。

## OSM 用語選定の根拠 (議論ログ)

ラベルとして `Add Entire Building` を採用。

| 候補 | 評価 |
|---|---|
| **Add Entire Building** ✅ | OSM の `type=building` relation に直接対応。singular/plural 曖昧なし。Phase 4-C "This part only" との対比明確 |
| Add All Parts ❌ | "parts" は OSM では role=part 限定で、outline を含めないニュアンス。outline を click した時に意味破綻 |
| Add Complete Building ❌ | "completeness" (= 完成) と混同しやすい |
| Add Entire Section ❌ | OSM に「section」エンティティ無し。singular に読みやすく "all sections" との対比で混乱 |

## Test plan

- [x] `npm run test:unit`: 1182 passing (前回 1174 + 新規 8)
- [x] `npm run test:browser`: 585 passing
- [x] `npm run lint`: 0 errors
- [ ] ローカル `npm run start` で実 API (Kochi mesh 50332481 の 14 parts 建物) を選択 → Inspector に "Add Entire Building" ボタン + 情報行が表示されることを確認

## スコープ外 (後続)

- **Phase 4-B-2**: relation メンバーの Pixi 二次ハイライト (rendering 改修、別 Issue)
- **Phase 4-C**: 部分 accept トグル ("Add this part only" 2nd ボタン)

## 関連

- `nyampire/Rapid#12` (Phase 3: cascade accept) ✅
- `nyampire/Rapid#14` (Phase 4-A: relation conflation) ✅
- 本 PR (Phase 4-B-1)
