### PR TITLE
Phase 4-C: 'Add Only This Feature' opt-out for relation cascade

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1119,6 +1119,11 @@ en:
       label: Add Entire Building
       description: This way is part of a multi-section building (outline + parts). Selecting this will add the outline, every part, and the relation together so the OSM structure stays consistent.
       tooltip: Add the entire building (outline and all parts) to the map.
+    option_accept_only_this:
+      label: Add Only This Feature
+      description: This way is part of a multi-section building, but you can also add just this one way without the rest of the structure. The outline and other parts will stay as suggestions.
+      annotation: Added a single feature from a Rapid building.
+      tooltip: Add only the selected way, without the rest of the building structure.
     multi_section_building_info:
       one: This way is part of a multi-section building ({n} part).
       other: This way is part of a multi-section building ({n} parts).

--- a/data/l10n/core.en.json
+++ b/data/l10n/core.en.json
@@ -1399,6 +1399,12 @@
         "description": "This way is part of a multi-section building (outline + parts). Selecting this will add the outline, every part, and the relation together so the OSM structure stays consistent.",
         "tooltip": "Add the entire building (outline and all parts) to the map."
       },
+      "option_accept_only_this": {
+        "label": "Add Only This Feature",
+        "description": "This way is part of a multi-section building, but you can also add just this one way without the rest of the structure. The outline and other parts will stay as suggestions.",
+        "annotation": "Added a single feature from a Rapid building.",
+        "tooltip": "Add only the selected way, without the rest of the building structure."
+      },
       "multi_section_building_info": {
         "one": "This way is part of a multi-section building ({n} part).",
         "other": "This way is part of a multi-section building ({n} parts)."

--- a/modules/actions/rapid_accept_feature.js
+++ b/modules/actions/rapid_accept_feature.js
@@ -72,7 +72,12 @@ function removeMetadata(entity) {
 }
 
 
-export function actionRapidAcceptFeature(entityID, extGraph) {
+export function actionRapidAcceptFeature(entityID, extGraph, options) {
+    // Phase 4-C: skipCascade=true で「外側の entry point の cascade のみ抑制」する。
+    // acceptRelation 内部の member 走査 (= 入れ子 acceptWay) は inProgressRelations で
+    // 自然に再 cascade されない構造なので、このフラグは entry 1段目だけに効けば十分。
+    var skipOuterCascade = !!(options && options.skipCascade);
+
     return function(graph) {
         var seenRelations = {};       // 完了済 relation (relation→relation 再帰防止 + 結果キャッシュ)
         var inProgressRelations = {}; // 処理中 relation (way→relation の再 cascade 防止)
@@ -111,13 +116,18 @@ export function actionRapidAcceptFeature(entityID, extGraph) {
             //
             // 注意: acceptRelation の中で member 各 way に対し acceptWay を再帰呼びする
             // ため、inProgressRelations で進行中の親 relation への二重 cascade を防ぐ。
-            var parents = extGraph.parentRelations(extWay);
-            for (var i = 0; i < parents.length; i++) {
-                var parent = parents[i];
-                if (parent.tags && parent.tags.type === 'building'
-                    && !seenRelations[parent.id]
-                    && !inProgressRelations[parent.id]) {
-                    return acceptRelation(parent);
+            //
+            // Phase 4-C: options.skipCascade で「relation を組まずこの way だけ追加」する
+            // opt-out を提供。relation cascade 検出ループ全体を bypass する。
+            if (!skipOuterCascade) {
+                var parents = extGraph.parentRelations(extWay);
+                for (var i = 0; i < parents.length; i++) {
+                    var parent = parents[i];
+                    if (parent.tags && parent.tags.type === 'building'
+                        && !seenRelations[parent.id]
+                        && !inProgressRelations[parent.id]) {
+                        return acceptRelation(parent);
+                    }
                 }
             }
 

--- a/modules/ui/UiRapidInspector.js
+++ b/modules/ui/UiRapidInspector.js
@@ -160,7 +160,7 @@ export class UiRapidInspector {
    * acceptFeature
    * Called when the user presses Add Feature.
    * @param  {Event}  e?         - triggering event (if any)
-   * @param  {Object} d?         - object bound to the selection (i.e. the command) (not used)
+   * @param  {Object} d?         - object bound to the choice (Phase 4-C: skipCascade flag を読む)
    * @param  {string} nextMode?  - optional next mode to enter after accepting ('move' or 'rotate')
    */
   acceptFeature(e, d, nextMode) {
@@ -189,18 +189,22 @@ export class UiRapidInspector {
     const datasetID = datum.__datasetid__.replace('-conflated', '');
     const dataset = rapid.datasets.get(datasetID);
 
+    // Phase 4-C: choice の skipCascade フラグを action に渡す
+    const skipCascade = !!(d && d.skipCascade);
+    const annotationStringID = d?.annotationStringID || 'rapid_inspector.option_accept.annotation';
+
     // In place of a string annotation, this introduces an "object-style"
     // annotation, where "type" and "description" are standard keys,
     // and there may be additional properties. Note that this will be
     // serialized to JSON while saving undo/redo state in editor.save().
     const annotation = {
       type: 'rapid_accept_feature',
-      description: l10n.t('rapid_inspector.option_accept.annotation'),
+      description: l10n.t(annotationStringID),
       entityID: datum.id,
       dataUsed: dataset?.dataUsed || [datasetID]
     };
 
-    editor.perform(actionRapidAcceptFeature(datum.id, graph));
+    editor.perform(actionRapidAcceptFeature(datum.id, graph, { skipCascade }));
     editor.commit({ annotation: annotation, selectedIDs: [datum.id] });
 
     // What next
@@ -421,6 +425,7 @@ export class UiRapidInspector {
     const l10n = context.systems.l10n;
 
     // Phase 4-B-1: building relation member の場合は label / description を切り替え
+    // Phase 4-C: building relation member の場合は「この feature のみ追加」の opt-out を追加
     const buildingInfo = this._getBuildingRelationInfo();
     const acceptLabelStringID = buildingInfo
       ? 'rapid_inspector.option_accept_entire_building.label'
@@ -437,15 +442,31 @@ export class UiRapidInspector {
         referenceStringID: acceptReferenceStringID,
         tooltip: this.AcceptTooltip,
         onClick: this.acceptFeature
-      }, {
-        key: 'ignore',
-        iconName: '#rapid-icon-rapid-minus-circle',
-        labelStringID: 'rapid_inspector.option_ignore.label',
-        referenceStringID: 'rapid_inspector.option_ignore.description',
-        tooltip: this.IgnoreTooltip,
-        onClick: this.ignoreFeature
       }
     ];
+
+    // Phase 4-C: relation member 時は「この feature だけ追加」 (cascade なし) を追加
+    if (buildingInfo) {
+      choiceData.push({
+        key: 'accept_only_this',
+        iconName: '#rapid-icon-rapid-plus-circle',
+        labelStringID: 'rapid_inspector.option_accept_only_this.label',
+        referenceStringID: 'rapid_inspector.option_accept_only_this.description',
+        annotationStringID: 'rapid_inspector.option_accept_only_this.annotation',
+        tooltip: this.AcceptTooltip,
+        onClick: this.acceptFeature,
+        skipCascade: true
+      });
+    }
+
+    choiceData.push({
+      key: 'ignore',
+      iconName: '#rapid-icon-rapid-minus-circle',
+      labelStringID: 'rapid_inspector.option_ignore.label',
+      referenceStringID: 'rapid_inspector.option_ignore.description',
+      tooltip: this.IgnoreTooltip,
+      onClick: this.ignoreFeature
+    });
 
     let $choices = $selection.selectAll('.rapid-inspector-choices')
       .data([0]);
@@ -463,12 +484,6 @@ export class UiRapidInspector {
     $$choices
       .append('p')
       .attr('class', 'rapid-inspector-multi-section-building-info');
-
-    $$choices.selectAll('.rapid-inspector-choice')
-      .data(choiceData, d => d.key)
-      .enter()
-      .append('div')
-      .attr('class', d => `rapid-inspector-choice rapid-inspector-choice-${d.key}`);
 
     // update
     $choices = $choices.merge($$choices);
@@ -489,9 +504,17 @@ export class UiRapidInspector {
         .text('');
     }
 
-    // choices の labelStringID 等が building 文脈で切り替わるよう、毎回データを更新
-    $choices.selectAll('.rapid-inspector-choice')
-      .data(choiceData, d => d.key)
+    // Phase 4-C: choice の出入り (relation 文脈で 2→3 ボタン化) に対応する
+    // enter / update / exit パターン。labelStringID 切り替えと併せて毎回データ更新。
+    const $choiceItems = $choices.selectAll('.rapid-inspector-choice')
+      .data(choiceData, d => d.key);
+
+    $choiceItems.exit().remove();
+
+    $choiceItems.enter()
+      .append('div')
+      .attr('class', d => `rapid-inspector-choice rapid-inspector-choice-${d.key}`)
+      .merge($choiceItems)
       .each(this.renderChoice);
   }
 

--- a/test/unit/actions/rapid_accept_feature.test.js
+++ b/test/unit/actions/rapid_accept_feature.test.js
@@ -192,4 +192,108 @@ describe('actionRapidAcceptFeature', () => {
         // 既存挙動: 単独 way のみ accept
         assert.ok(graph.hasEntity('w_solo'));
     });
+
+
+    // ----------------------------------------------------------------------
+    // Phase 4-C: skipCascade opt-out
+    // 「relation 全体ではなく、この way だけ追加したい」上級ユーザー向けオプション
+    // ----------------------------------------------------------------------
+
+    it('skipCascade=true adds only the way, not the parent building relation', () => {
+        const n1 = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+        const outline = Rapid.osmWay({ id: 'w_outline', nodes: ['n1'], tags: { building: 'yes' } });
+        const part = Rapid.osmWay({ id: 'w_part', nodes: ['n1'], tags: { 'building:part': 'yes' } });
+        const relation = Rapid.osmRelation({
+            id: 'r_building',
+            tags: { type: 'building', building: 'yes' },
+            members: [
+                { id: outline.id, type: 'way', role: 'outline' },
+                { id: part.id, type: 'way', role: 'part' },
+            ],
+        });
+        const extGraph = new Rapid.Graph([n1, outline, part, relation]);
+
+        // part に対して skipCascade=true で accept
+        const graph = Rapid.actionRapidAcceptFeature(part.id, extGraph, { skipCascade: true })(new Rapid.Graph());
+
+        // part だけが追加され、relation / outline は追加されない
+        assert.ok(graph.hasEntity('w_part'));
+        assert.ok(!graph.hasEntity('r_building'), 'relation should NOT be cascaded when skipCascade=true');
+        assert.ok(!graph.hasEntity('w_outline'), 'outline should NOT be cascaded when skipCascade=true');
+    });
+
+    it('skipCascade=true on outline adds only the outline, not parts or relation', () => {
+        const n1 = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+        const outline = Rapid.osmWay({ id: 'w_outline', nodes: ['n1'], tags: { building: 'yes' } });
+        const part = Rapid.osmWay({ id: 'w_part', nodes: ['n1'], tags: { 'building:part': 'yes' } });
+        const relation = Rapid.osmRelation({
+            id: 'r_building',
+            tags: { type: 'building' },
+            members: [
+                { id: outline.id, type: 'way', role: 'outline' },
+                { id: part.id, type: 'way', role: 'part' },
+            ],
+        });
+        const extGraph = new Rapid.Graph([n1, outline, part, relation]);
+
+        const graph = Rapid.actionRapidAcceptFeature(outline.id, extGraph, { skipCascade: true })(new Rapid.Graph());
+
+        assert.ok(graph.hasEntity('w_outline'));
+        assert.ok(!graph.hasEntity('r_building'));
+        assert.ok(!graph.hasEntity('w_part'));
+    });
+
+    it('skipCascade=false (or omitted) cascades to the parent building relation', () => {
+        const n1 = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+        const outline = Rapid.osmWay({ id: 'w_outline', nodes: ['n1'], tags: { building: 'yes' } });
+        const part = Rapid.osmWay({ id: 'w_part', nodes: ['n1'], tags: { 'building:part': 'yes' } });
+        const relation = Rapid.osmRelation({
+            id: 'r_building',
+            tags: { type: 'building' },
+            members: [
+                { id: outline.id, type: 'way', role: 'outline' },
+                { id: part.id, type: 'way', role: 'part' },
+            ],
+        });
+        const extGraph = new Rapid.Graph([n1, outline, part, relation]);
+
+        // skipCascade=false: 既存の Phase 3 挙動 (relation 全体追加)
+        const graphFalse = Rapid.actionRapidAcceptFeature(part.id, extGraph, { skipCascade: false })(new Rapid.Graph());
+        assert.ok(graphFalse.hasEntity('r_building'));
+        assert.ok(graphFalse.hasEntity('w_outline'));
+        assert.ok(graphFalse.hasEntity('w_part'));
+
+        // options 省略時: 同じ挙動 (cascade)
+        const graphOmit = Rapid.actionRapidAcceptFeature(part.id, extGraph)(new Rapid.Graph());
+        assert.ok(graphOmit.hasEntity('r_building'));
+        assert.ok(graphOmit.hasEntity('w_outline'));
+        assert.ok(graphOmit.hasEntity('w_part'));
+    });
+
+    it('skipCascade=true on a relation directly still processes the relation and its members', () => {
+        // user が直接 relation を accept した時、skipCascade は entry が way の場合のみ意味を持つ。
+        // relation の入口は acceptRelation で、その内部の acceptWay 再帰は inProgressRelations で
+        // 自然に cascade されないので、skipCascade=true でも relation の全体追加は機能する。
+        const n1 = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+        const outline = Rapid.osmWay({ id: 'w_outline', nodes: ['n1'], tags: { building: 'yes' } });
+        const part = Rapid.osmWay({ id: 'w_part', nodes: ['n1'], tags: { 'building:part': 'yes' } });
+        const relation = Rapid.osmRelation({
+            id: 'r_building',
+            tags: { type: 'building' },
+            members: [
+                { id: outline.id, type: 'way', role: 'outline' },
+                { id: part.id, type: 'way', role: 'part' },
+            ],
+        });
+        const extGraph = new Rapid.Graph([n1, outline, part, relation]);
+
+        const graph = Rapid.actionRapidAcceptFeature(relation.id, extGraph, { skipCascade: true })(new Rapid.Graph());
+
+        // relation を entry にした場合、skipCascade は単に「内部 acceptWay の冒頭 cascade 判定を bypass する」
+        // 効果しかなく、acceptRelation 自体は member を順に accept する。
+        // 結果として relation + 全 member が graph に入る。
+        assert.ok(graph.hasEntity('r_building'));
+        assert.ok(graph.hasEntity('w_outline'));
+        assert.ok(graph.hasEntity('w_part'));
+    });
 });


### PR DESCRIPTION
## Summary

- `actionRapidAcceptFeature` に第3引数 `options.skipCascade` を追加 (既存呼び出しは無影響)
- Inspector で datum が building relation member の時、3 ボタン表示 (`Add Entire Building` / **`Add Only This Feature`** / `Ignore`)
- d3 の enter/update/exit パターンで 2↔3 ボタンの動的切り替えを正しく処理
- 新規 unit test 4 件 (skipCascade の挙動)

Closes #18

## 背景

Phase 3 で cascade accept (relation member クリック → relation 全体追加)、Phase 4-B-1 で "Add Entire Building" ラベル切り替えを実装。本 PR は **その対称の opt-out** を提供:

ユースケース:
- 既存 OSM に簡易な建物 outline がすでに存在し、PLATEAU の outline は要らないが特定の part だけ追加したい
- LOD2 のうち一部だけ実地調査と照合してから追加・編集したい
- まずは1棟だけ試して挙動を確認したい

## 変更点

### `modules/actions/rapid_accept_feature.js`

```javascript
export function actionRapidAcceptFeature(entityID, extGraph, options) {
    var skipOuterCascade = !!(options && options.skipCascade);
    return function(graph) {
        ...
        function acceptWay(extWay) {
            if (!skipOuterCascade) {
                // Phase 3 cascade ロジック (relation 全体追加)
                var parents = extGraph.parentRelations(extWay);
                ...
            }
            // 通常の way accept (Phase 3 と同じ)
        }
    };
}
```

`skipCascade` は **外側 entry の cascade のみ** 抑制:
- way entry + skipCascade=true: way だけ追加、relation/outline/parts は無関与
- way entry + skipCascade=false (省略時): Phase 3 通り relation 全体追加
- relation entry + skipCascade=true: acceptRelation が member を順に accept (内部 acceptWay は inProgressRelations で cascade されないため、結果は省略時と同じ)

### `modules/ui/UiRapidInspector.js`

`renderChoices` で datum が building relation の member の場合のみ 3 ボタン構成:

```
[ Add Entire Building          ]  ← cascade あり (default、Phase 4-B-1)
[ Add Only This Feature        ]  ← cascade なし (Phase 4-C 新規)
[ Ignore This Feature          ]
```

d3 の enter/update/exit パターンを採用し、選択切り替え時に choice の出入りが滑らかに動作。

`acceptFeature(e, d, nextMode)` は choice の bound datum から `d.skipCascade` を読んで action に渡す。annotation も choice 由来 (`d.annotationStringID`) を読むので undo 履歴に「Add Entire Building」「Add Only This Feature」どちらの操作か区別できる。

### i18n (`data/core.yaml`)

```yaml
option_accept_only_this:
  label: Add Only This Feature
  description: This way is part of a multi-section building, but you can also add just this one way without the rest of the structure. The outline and other parts will stay as suggestions.
  annotation: Added a single feature from a Rapid building.
  tooltip: Add only the selected way, without the rest of the building structure.
```

## ラベル選定の根拠

| 候補 | 評価 |
|---|---|
| **Add Only This Feature** ✅ | 既存 "Add This Feature" の自然な拡張、outline/part 両対応 (OSM 用語破綻なし) |
| Add This Part Only ❌ | "part" は OSM role=part 限定、outline 文脈で意味が破綻 |
| Add This Way Only ❌ | OSM 内部用語で初心者にやや冷たい |

## Test plan

- [x] `npm run test:unit`: **1186 passing** (前回 1182 + 新規 4)
- [x] `npm run test:browser`: 585 passing
- [x] `npm run lint`: 0 errors
- [ ] ローカル `npm run start` で実 API (Kochi mesh 50332481 の 14 parts 建物) を選択 → 3 ボタンが表示されることを確認
- [ ] Add Only This Feature を押した時、その way だけ OSM に追加され、relation/outline/他 parts は追加されないことを Properties パネルで確認

## スコープ外 (後続)

- **Phase 4-B-2**: relation メンバーの Pixi 二次ハイライト (rendering 改修、別 Issue)

## 関連

- `nyampire/Rapid#12` (Phase 3: cascade accept) ✅
- `nyampire/Rapid#14` (Phase 4-A: relation conflation) ✅
- `nyampire/Rapid#16` (Phase 4-B-1: inspector hint + Entire Building label) ✅
- 本 PR (Phase 4-C: opt-out toggle)
- 後続: Phase 4-B-2 (Pixi 視覚改修)
