### PR TITLE
Phase 4-B-2: Highlight relation members on hover for multi-section buildings

### DIFF
--- a/modules/services/MapWithAIService.js
+++ b/modules/services/MapWithAIService.js
@@ -5,7 +5,7 @@ import { utilStringQs } from '@rapid-sdk/util';
 import { AbstractSystem } from '../core/AbstractSystem.js';
 import { Graph, Tree, RapidDataset } from '../core/lib/index.js';
 import { osmEntity, osmNode, osmRelation, osmWay } from '../osm/index.js';
-import { utilFetchResponse } from '../util/index.js';
+import { utilFetchResponse, utilBuildingRelationInfo } from '../util/index.js';
 
 
 const APIROOT = 'https://mapwith.ai/maps/ml_roads';
@@ -44,9 +44,14 @@ export class MapWithAIService extends AbstractSystem {
     this._coverageData = null;          // GeoJSON FeatureCollection or null
     this._coveragePromise = null;       // Promise<FeatureCollection> when inflight
 
+    // Phase 4-B-2: hover で highlight class を set した relation member の ID 集合。
+    // 同じ ID 群を自分で unsetClass するための追跡用 (他用途の 'highlight' に干渉しない)。
+    this._hoveredRelationSiblings = new Set();
+
     // Ensure methods used as callbacks always have `this` bound correctly.
     this._parseNode = this._parseNode.bind(this);
     this._parseWay = this._parseWay.bind(this);
+    this._onHoverchange = this._onHoverchange.bind(this);
   }
 
 
@@ -98,7 +103,63 @@ export class MapWithAIService extends AbstractSystem {
       });
     }
 
+    // Phase 4-B-2: PLATEAU LOD2 multi-section building の relation member を
+    // hover した時、同じ relation の他 members も視覚的にハイライト。
+    // 'highlight' クラス (Pixi で blue glow) を流用、独自スタイル追加なし。
+    const hover = this.context.behaviors && this.context.behaviors.hover;
+    if (hover && typeof hover.on === 'function') {
+      hover.on('hoverchange', this._onHoverchange);
+    }
+
     return Promise.resolve();
+  }
+
+
+  /**
+   * _onHoverchange
+   * Phase 4-B-2: hover 対象が PLATEAU LOD2 building relation のメンバー way なら、
+   * 同 relation の他 members に 'highlight' クラスを set し、cascade 対象を視覚化する。
+   *
+   * 既存の `highlight` クラスは PixiFeaturePolygon 等で blue glow としてレンダリング済。
+   * 他用途 (edit_menu 等) と衝突しないよう、自分が set した ID は `_hoveredRelationSiblings`
+   * で追跡し、cleanup 時はその ID 群だけ unsetClass する (clearClass は使わない)。
+   */
+  _onHoverchange(eventData) {
+    const target = eventData && eventData.target;
+    const layer = target && target.layer;
+    const data = target && target.data;
+
+    // 1. 前回 set した siblings の highlight を解除 (自分が set した ID のみ)
+    if (this._hoveredRelationSiblings.size > 0) {
+      const scene = this.context.systems.gfx && this.context.systems.gfx.scene;
+      if (scene) {
+        for (const layerID of ['rapid', 'osm']) {
+          const l = scene.layers && scene.layers.get && scene.layers.get(layerID);
+          if (!l || typeof l.unsetClass !== 'function') continue;
+          for (const id of this._hoveredRelationSiblings) {
+            l.unsetClass('highlight', id);
+          }
+        }
+      }
+      this._hoveredRelationSiblings.clear();
+    }
+
+    // 2. hover 対象が無いか、自サービスの data でなければ何もしない
+    if (!layer || !data || data.__service__ !== 'mapwithai') return;
+    if (typeof layer.setClass !== 'function') return;
+
+    const datasetGraph = this.graph(data.__datasetid__);
+    if (!datasetGraph) return;
+
+    const info = utilBuildingRelationInfo(data, datasetGraph);
+    if (!info) return;
+
+    // 3. relation の他メンバー (自分以外) に highlight を set
+    for (const member of info.relation.members || []) {
+      if (!member || member.id === data.id) continue;
+      layer.setClass('highlight', member.id);
+      this._hoveredRelationSiblings.add(member.id);
+    }
   }
 
 

--- a/test/browser/services/MapWithAIService.test.js
+++ b/test/browser/services/MapWithAIService.test.js
@@ -566,4 +566,129 @@ describe('MapWithAIService', () => {
     });
   });
 
+
+  // ----------------------------------------------------------------------
+  // Phase 4-B-2: hover で relation member を視覚的にハイライト
+  // ----------------------------------------------------------------------
+
+  describe('#_onHoverchange', () => {
+    /**
+     * 必要な mock:
+     * - context.systems.gfx.scene.layers.get(layerID) → layer-like object
+     * - layer.setClass / layer.unsetClass を spy 対応
+     * - service の datasets[].graph に entity + relation を仕込む
+     * - hover data.__service__ === 'mapwithai', data.__datasetid__ === 'pj'
+     */
+    function makeLayerMock() {
+      const setCalls = [];
+      const unsetCalls = [];
+      return {
+        setClass(klass, id) { setCalls.push([klass, id]); },
+        unsetClass(klass, id) { unsetCalls.push([klass, id]); },
+        getSetCalls: () => setCalls,
+        getUnsetCalls: () => unsetCalls,
+      };
+    }
+
+    function makeBuildingRelationDataset(serviceInstance, datasetID) {
+      // outline / part / relation を datasets[datasetID].graph に仕込む
+      const outline = Rapid.osmWay({ id: 'w_outline', nodes: ['n1'], tags: { building: 'yes' } });
+      const part = Rapid.osmWay({ id: 'w_part', nodes: ['n1'], tags: { 'building:part': 'yes' } });
+      const relation = Rapid.osmRelation({
+        id: 'r_building',
+        tags: { type: 'building', building: 'yes' },
+        members: [
+          { id: outline.id, type: 'way', role: 'outline' },
+          { id: part.id, type: 'way', role: 'part' },
+        ],
+      });
+      const node = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+      let graph = new Rapid.Graph([node, outline, part, relation]);
+      serviceInstance._datasets[datasetID] = {
+        id: datasetID,
+        graph: graph,
+        tree: null,
+        cache: { inflight: {}, loaded: new Set(), seen: new Set(), seenFirstNodeID: new Set(), splitWays: new Map() },
+      };
+      // service.graph() が data.__datasetid__ から graph を返すように
+      // 既存の service.graph() メソッドがあれば自動的に動く想定。
+      // (MapWithAIService に graph(datasetID) メソッドがあることを前提)
+      return { outline, part, relation };
+    }
+
+    it('sets highlight on other relation members when hovering a member way', () => {
+      const layer = makeLayerMock();
+      const built = makeBuildingRelationDataset(_service, 'pj');
+
+      // hover 対象 = part の Plateau データ
+      // production と同じく way instance 自体に metadata を attach (prototype を残す)
+      const hoverData = built.part;
+      hoverData.__service__ = 'mapwithai';
+      hoverData.__datasetid__ = 'pj';
+
+      _service._onHoverchange({ target: { layer: layer, data: hoverData } });
+
+      const sets = layer.getSetCalls();
+      // outline と part のうち、自分 (part) 以外 = outline にだけ highlight が乗る
+      const highlightedIDs = sets
+        .filter(([klass, _]) => klass === 'highlight')
+        .map(([_, id]) => id);
+      expect(highlightedIDs).to.include('w_outline');
+      expect(highlightedIDs).to.not.include('w_part');
+    });
+
+    it('does nothing for hover targets not in the mapwithai service', () => {
+      const layer = makeLayerMock();
+      makeBuildingRelationDataset(_service, 'pj');
+
+      const hoverData = { id: 'w_other', type: 'way', __service__: 'osm', __datasetid__: 'pj' };
+
+      _service._onHoverchange({ target: { layer: layer, data: hoverData } });
+
+      expect(layer.getSetCalls()).to.have.lengthOf(0);
+    });
+
+    it('does nothing for ways with no parent building relation', () => {
+      const layer = makeLayerMock();
+      // dataset を仕込むが、way は relation の member ではない
+      const solo = Rapid.osmWay({ id: 'w_solo', nodes: [] });
+      const graph = new Rapid.Graph([solo]);
+      _service._datasets.pj_solo = { id: 'pj_solo', graph: graph, tree: null, cache: {} };
+
+      solo.__service__ = 'mapwithai';
+      solo.__datasetid__ = 'pj_solo';
+
+      _service._onHoverchange({ target: { layer: layer, data: solo } });
+      expect(layer.getSetCalls()).to.have.lengthOf(0);
+    });
+
+    it('clears previous siblings when hover moves to a different feature', () => {
+      const layer = makeLayerMock();
+
+      // scene mock を context に仕込む (cleanup の経路で必要)
+      const sceneLayers = new Map([['rapid', layer]]);
+      _service.context.systems.gfx = {
+        scene: { layers: sceneLayers },
+        deferredRedraw() {},
+        immediateRedraw() {},
+      };
+
+      const built = makeBuildingRelationDataset(_service, 'pj');
+
+      // 1回目: part を hover → outline に highlight
+      built.part.__service__ = 'mapwithai';
+      built.part.__datasetid__ = 'pj';
+      _service._onHoverchange({ target: { layer: layer, data: built.part } });
+
+      // 2回目: hover を外す (target が null)
+      _service._onHoverchange({ target: null });
+
+      const unsets = layer.getUnsetCalls();
+      const unsetIDs = unsets
+        .filter(([klass, _]) => klass === 'highlight')
+        .map(([_, id]) => id);
+      expect(unsetIDs).to.include('w_outline');
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary

- PLATEAU LOD2 multi-section building の relation member を hover した時、同 relation の他 members に既存の `highlight` クラスを set し、cascade 対象を視覚的にハイライト
- `MapWithAIService` に hover listener を追加 (PLATEAU 固有ロジックを service に集約)
- 自分が set した ID のみ追跡 → 他用途 (edit_menu 等) の highlight に干渉しない
- ユニットテスト 4 件追加

Closes #20

## 背景

Phase 4-B-1 で Inspector に「This way is part of a multi-section building」情報行を表示するようにしたが、**地図上 (Pixi 描画)** では cascade 対象が見えないため、ユーザーが `Add Entire Building` を押す前に「何が一括追加されるか」を視覚で把握できなかった。

本 PR は hover 時に relation members を **blue glow** でハイライトする視覚補助。

## 変更点

### `modules/services/MapWithAIService.js`

```javascript
// constructor
this._hoveredRelationSiblings = new Set();
this._onHoverchange = this._onHoverchange.bind(this);

// startAsync (既存 editor.on 同様、cleanup は app teardown まで暗黙)
const hover = this.context.behaviors && this.context.behaviors.hover;
if (hover && typeof hover.on === 'function') {
    hover.on('hoverchange', this._onHoverchange);
}

// 新規メソッド
_onHoverchange(eventData) {
    // 1. 前回 set した siblings の highlight を解除 (自分が set した ID のみ)
    if (this._hoveredRelationSiblings.size > 0) { ... }

    // 2. 今回 hover 対象が mapwithai の way なら、relation member を取得
    if (!layer || !data || data.__service__ !== 'mapwithai') return;
    const info = utilBuildingRelationInfo(data, this.graph(data.__datasetid__));
    if (!info) return;

    // 3. 他 members に 'highlight' クラスを set
    for (const member of info.relation.members) {
        if (member.id !== data.id) {
            layer.setClass('highlight', member.id);
            this._hoveredRelationSiblings.add(member.id);
        }
    }
}
```

### スタイル: 既存 `highlight` クラス再利用

| 状態 | クラス | 表現 |
|---|---|---|
| 現在 hover している way | `hover` | yellow glow (既存) |
| 同 relation の他 members | **`highlight`** | blue glow (既存、`PixiFeaturePolygon.updateHalo` で blue 0x7092ff) を流用 |

→ **新規 Pixi スタイル追加無し**、視覚改修を最小コストで実現。

### 干渉回避

既存の `highlight` クラスは `edit_menu` 等でも使われる。グローバルな `clearClass('highlight')` を呼ぶと他用途の highlight も消えてしまうため、

- `_hoveredRelationSiblings` Set で自分が set した ID を記録
- cleanup 時はその ID 群だけ `unsetClass` で個別解除

他用途の highlight 表示には触れない設計。

## テスト

`test/browser/services/MapWithAIService.test.js` の `#_onHoverchange`:

| ケース | 期待 |
|---|---|
| relation member を hover | 自分以外の members に `highlight` 集中 (自分は `hover` のまま) |
| hover が解除される (target=null) | 前回 set した IDs が unsetClass で解除される |
| 非 mapwithai service の data | noop |
| relation 持たない単独 way | noop |

prototype 経由の `type='way'` を保つため、テストでは Object.assign で新規オブジェクトを作らず、way instance に直接 metadata を attach (production の _parseEntity と同じパターン)。

## Test plan

- [x] `npm run test:browser`: **589 passing** (前回 585 + 新規 4)
- [x] `npm run test:unit`: 1186 passing
- [x] `npm run lint`: 0 errors
- [ ] ローカル `npm run start` で Kochi mesh 50332481 の 14 parts 建物を hover → outline + 13 parts (合計 14 way) が blue glow で highlighted されるか確認
- [ ] Hover が外れたとき highlight が消えるか確認
- [ ] OSM 既存建物との衝突で reject されている地点では、hover しても highlight 出ないことを確認

## スコープ外

- **Select 時 (クリック後) の sibling highlight**: v1 では未対応。`SelectOsmMode` 等の改修範囲が広く別 Issue
- **アニメーション / フェード**: 即時 on/off で十分

## 関連

- `nyampire/Rapid#12` (Phase 3) ✅
- `nyampire/Rapid#14` (Phase 4-A) ✅
- `nyampire/Rapid#16` (Phase 4-B-1) ✅
- `nyampire/Rapid#18` (Phase 4-C) ✅
- 本 PR (Phase 4-B-2: hover visual hint)

**Phase 4 全工程完了予定。** マージ後、Kochi 全域再 import が ready 状態に。
