### PR TITLE
Phase 4 follow-up: cascade accept redraw + silent throw + label consistency

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1116,9 +1116,9 @@ en:
       disabled: To help improve OSM data quality, we only allow {n} AI features to be added in each mapping session. Please try to fix issues on your edits so far. You will be able to add more AI features after saving.
       disabled_flash: To help improve OSM data quality, we only allow {n} AI Features to be added in each mapping session.
     option_accept_entire_building:
-      label: Add Entire Building
+      label: Add Entire Feature
       description: This way is part of a multi-section building (outline + parts). Selecting this will add the outline, every part, and the relation together so the OSM structure stays consistent.
-      tooltip: Add the entire building (outline and all parts) to the map.
+      tooltip: Add the entire feature group (outline and all parts) to the map.
     option_accept_only_this:
       label: Add Only This Feature
       description: This way is part of a multi-section building, but you can also add just this one way without the rest of the structure. The outline and other parts will stay as suggestions.

--- a/data/l10n/core.en.json
+++ b/data/l10n/core.en.json
@@ -1395,9 +1395,9 @@
         "disabled_flash": "To help improve OSM data quality, we only allow {n} AI Features to be added in each mapping session."
       },
       "option_accept_entire_building": {
-        "label": "Add Entire Building",
+        "label": "Add Entire Feature",
         "description": "This way is part of a multi-section building (outline + parts). Selecting this will add the outline, every part, and the relation together so the OSM structure stays consistent.",
-        "tooltip": "Add the entire building (outline and all parts) to the map."
+        "tooltip": "Add the entire feature group (outline and all parts) to the map."
       },
       "option_accept_only_this": {
         "label": "Add Only This Feature",

--- a/modules/actions/rapid_accept_feature.js
+++ b/modules/actions/rapid_accept_feature.js
@@ -78,6 +78,15 @@ export function actionRapidAcceptFeature(entityID, extGraph, options) {
     // 自然に再 cascade されない構造なので、このフラグは entry 1段目だけに効けば十分。
     var skipOuterCascade = !!(options && options.skipCascade);
 
+    // Phase 4-B-2 (描画修正): cascade で実際に accept された全 entity ID を集める。
+    // 呼び出し側 (UiRapidInspector) はこれを annotation.entityIDs に詰めて commit し、
+    // RapidSystem._stablechange でこの ID 群を一括 acceptIDs に追加することで、
+    // Rapid layer のフィルタが cascade 全 member に効くようにする。
+    var acceptedIDs = (options && Array.isArray(options.acceptedIDs)) ? options.acceptedIDs : null;
+    function recordAccepted(id) {
+        if (acceptedIDs && id) acceptedIDs.push(id);
+    }
+
     return function(graph) {
         var seenRelations = {};       // 完了済 relation (relation→relation 再帰防止 + 結果キャッシュ)
         var inProgressRelations = {}; // 処理中 relation (way→relation の再 cascade 防止)
@@ -104,6 +113,7 @@ export function actionRapidAcceptFeature(entityID, extGraph, options) {
             removeMetadata(node);
 
             graph = graph.replace(node);
+            recordAccepted(node.id);
             return node;
         }
 
@@ -173,6 +183,7 @@ export function actionRapidAcceptFeature(entityID, extGraph, options) {
 
             way = way.update({ nodes: nodes });
             graph = graph.replace(way);
+            recordAccepted(way.id);
             return way;
         }
 
@@ -191,10 +202,10 @@ export function actionRapidAcceptFeature(entityID, extGraph, options) {
             removeMetadata(relation);
 
             var members = relation.members.map(function(member) {
-                var extEntity = extGraph.entity(member.id);
+                // extGraph.entity() は見つからない場合 throw するため、hasEntity を使う。
+                // bbox 外や未ロードの member 参照は保持しつつ、accept 自体はスキップする。
+                var extEntity = extGraph.hasEntity(member.id);
                 if (!extEntity) {
-                    // メンバーが extGraph に存在しない場合 (bbox 外などで dataset graph に入っていない)
-                    // → そのメンバー参照は保持しつつ accept はスキップ
                     return member;
                 }
                 var replacement;
@@ -215,6 +226,7 @@ export function actionRapidAcceptFeature(entityID, extGraph, options) {
             graph = graph.replace(relation);
             seenRelations[extRelation.id] = relation;
             delete inProgressRelations[extRelation.id];
+            recordAccepted(relation.id);
             return relation;
         }
 

--- a/modules/core/RapidSystem.js
+++ b/modules/core/RapidSystem.js
@@ -333,6 +333,11 @@ export class RapidSystem extends AbstractSystem {
    * _stablechange
    * This is called anytime the history changes, we recompute the accepted/ignored sets.
    * This can run on history change, undo, redo, or history restore.
+   *
+   * Phase 4-B-2 (描画修正): cascade accept で複数 entity が同時に受理された場合に対応するため
+   * annotation.entityIDs (配列) も読む。さらに 'stagingchange' (= MapSystem の redraw) が
+   * 先に発火するため、ここで acceptIDs を更新した後に gfx.deferredRedraw() を呼んで
+   * Rapid layer 等が新しい acceptIDs でフィルタを再評価できるよう確実に redraw を促す。
    */
   _stablechange() {
     const context = this.context;
@@ -351,10 +356,23 @@ export class RapidSystem extends AbstractSystem {
       const annotation = edit.annotation;
 
       if (annotation?.type === 'rapid_accept_feature') {
+        // Phase 4-B-2: cascade で受理された全 entity ID も追加
+        if (Array.isArray(annotation.entityIDs)) {
+          for (const id of annotation.entityIDs) {
+            if (id) this.acceptIDs.add(id);
+          }
+        }
         if (annotation.entityID)  this.acceptIDs.add(annotation.entityID);
       } else if (annotation?.type === 'rapid_ignore_feature') {
         if (annotation.entityID)  this.ignoreIDs.add(annotation.entityID);
       }
+    }
+
+    // acceptIDs / ignoreIDs 更新後に再描画を促す (stagingchange の先発で
+    // 古い acceptIDs のままレンダリングされた Rapid layer 等を最新状態にする)
+    const gfx = context.systems.gfx;
+    if (gfx && typeof gfx.deferredRedraw === 'function') {
+      gfx.deferredRedraw();
     }
   }
 

--- a/modules/ui/UiRapidInspector.js
+++ b/modules/ui/UiRapidInspector.js
@@ -193,6 +193,13 @@ export class UiRapidInspector {
     const skipCascade = !!(d && d.skipCascade);
     const annotationStringID = d?.annotationStringID || 'rapid_inspector.option_accept.annotation';
 
+    // Phase 4-B-2 (描画修正): cascade で受理した全 entity ID を集めて annotation に積む。
+    // RapidSystem._stablechange がこれを読み acceptIDs に追加することで、Rapid layer が
+    // cascade 全 member を即座にフィルタアウト (= 二重描画解消) する。
+    const acceptedIDs = [];
+
+    editor.perform(actionRapidAcceptFeature(datum.id, graph, { skipCascade, acceptedIDs }));
+
     // In place of a string annotation, this introduces an "object-style"
     // annotation, where "type" and "description" are standard keys,
     // and there may be additional properties. Note that this will be
@@ -201,10 +208,10 @@ export class UiRapidInspector {
       type: 'rapid_accept_feature',
       description: l10n.t(annotationStringID),
       entityID: datum.id,
+      entityIDs: acceptedIDs.length ? acceptedIDs.slice() : undefined,
       dataUsed: dataset?.dataUsed || [datasetID]
     };
 
-    editor.perform(actionRapidAcceptFeature(datum.id, graph, { skipCascade }));
     editor.commit({ annotation: annotation, selectedIDs: [datum.id] });
 
     // What next


### PR DESCRIPTION
## Summary

Phase 4 関連を本番動作確認した際に判明した 3 つの follow-up 課題を一括修正:

1. **描画ラグの解消**: `Add Entire Feature` (旧 Building) 後、Rapid 緑層が即時に消えない (zoom-in/out 要) 問題を修正
2. **silent throw の修正**: bbox 外メンバー参照で `acceptRelation` が無音失敗していた問題
3. **ラベルの一貫性**: `Add Entire Building` → `Add Entire Feature` (他ボタン Feature 表記と統一)

Closes #22

## 課題別の変更

### 1. 描画ラグ

**原因**: `editor.commit()` が `stagingchange` → `stablechange` の順で発火。`MapSystem` は `stagingchange` で即座に redraw、`RapidSystem._stablechange` はその後で `acceptIDs` を更新するため、描画時点で `acceptIDs` が古い。加えて annotation には clicked 単一 entityID しか記録されておらず、cascade 受理された他 14 個のメンバーは acceptIDs に乗らないまま緑表示が残る。

**修正**:

| ファイル | 変更 |
|---|---|
| `modules/actions/rapid_accept_feature.js` | `options.acceptedIDs` (Array) を受け取り、acceptNode/Way/Relation 経路で受理 ID を push |
| `modules/ui/UiRapidInspector.js` | `acceptedIDs=[]` を action に渡し、annotation.entityIDs に slice copy |
| `modules/core/RapidSystem.js` | `_stablechange` で annotation.entityIDs (配列) を読んで acceptIDs を一括追加 + 末尾で `gfx.deferredRedraw()` |

cascade 全 ID が acceptIDs に入り、その後 redraw で Rapid 層が最新 acceptIDs でフィルタを再評価する。

### 2. acceptRelation の silent throw

```javascript
// Before (Phase 3)
var extEntity = extGraph.entity(member.id);  // throws if not found
if (!extEntity) return member;  // never reached

// After
var extEntity = extGraph.hasEntity(member.id);  // returns undefined if not found
if (!extEntity) return member;  // safe fallback
```

bbox 境界などで dataset graph に未ロードな member 参照を、参照のみ維持して accept は skip する。これにより部分ロード状況でも cascade 全体は前進する。

### 3. ラベル変更

```yaml
option_accept_entire_building:    # key は内部識別子で変更しない
  label: Add Entire Feature       # Building → Feature
  description: This way is part of a multi-section building (outline + parts). Selecting this will add the outline, every part, and the relation together so the OSM structure stays consistent.
  tooltip: Add the entire feature group (outline and all parts) to the map.
```

3 ボタン (`Add This Feature` / `Add Only This Feature` / `Add Entire Feature` / `Ignore This Feature`) で「Feature」を一貫させ、視覚的整合性を改善。文脈情報は description と「This way is part of a multi-section building (N parts).」の prompt 補助行に集約。

## Test plan

- [x] `npm run test:unit`: 1186 passing (変更なし、既存テストは互換維持を確認)
- [x] `npm run test:browser`: 589 passing (変更なし)
- [x] `npm run lint`: 0 errors
- [x] **手動検証 (Kochi mesh 50332481, 14 parts 建物)**: 
  - `Add Entire Feature` 押下後、緑 Rapid 層が**即座に**消えて OSM 層描画に切り替わる ✓
  - `Add Only This Feature` 押下時はその way だけが OSM 化、relation/他 parts は緑のまま ✓

## 互換性

- `annotation.entityID` (legacy 単一フィールド) は維持。古い annotation を読む既存 history restore コードと互換
- 新 `annotation.entityIDs` は新形式、なければ entityID にフォールバック
- key 名 `option_accept_entire_building` は変更せず (内部識別子)、UI 表示文字列のみ変更
- 既存 PR 群 (Phase 4-A〜C, B-1, B-2) の挙動は維持しつつ、本 PR で表面的な不具合を解消

## 関連

- `nyampire/Rapid#12, #14, #16, #18, #20` (Phase 3 / 4-A / 4-B-1 / 4-C / 4-B-2) ✅
- 本 PR (Phase 4 follow-up)

これにて Phase 4 関連の実装は完全完了。マージ後、Kochi 全域再 import の議論に移行可能。
