### PR TITLE
Phase 4-B-3: Highlight relation members while a LOD2 building part is selected

### DIFF
--- a/modules/services/MapWithAIService.js
+++ b/modules/services/MapWithAIService.js
@@ -48,10 +48,15 @@ export class MapWithAIService extends AbstractSystem {
     // 同じ ID 群を自分で unsetClass するための追跡用 (他用途の 'highlight' に干渉しない)。
     this._hoveredRelationSiblings = new Set();
 
+    // Phase 4-B-3: select で highlight class を set した relation member の ID 集合。
+    // hover と同じ 'highlight' クラスを共有するため、cleanup 時に互いの claim を尊重する。
+    this._selectedRelationSiblings = new Set();
+
     // Ensure methods used as callbacks always have `this` bound correctly.
     this._parseNode = this._parseNode.bind(this);
     this._parseWay = this._parseWay.bind(this);
     this._onHoverchange = this._onHoverchange.bind(this);
+    this._onModeChange = this._onModeChange.bind(this);
   }
 
 
@@ -111,6 +116,13 @@ export class MapWithAIService extends AbstractSystem {
       hover.on('hoverchange', this._onHoverchange);
     }
 
+    // Phase 4-B-3: クリック選択時も relation の他 members を hover と同じ blue glow で
+    // 視覚化する。hover を外しても選択中は highlight が残るよう、cleanup は
+    // `_hoveredRelationSiblings` / `_selectedRelationSiblings` 間で互いの claim を尊重。
+    if (typeof this.context.on === 'function') {
+      this.context.on('modechange', this._onModeChange);
+    }
+
     return Promise.resolve();
   }
 
@@ -129,7 +141,8 @@ export class MapWithAIService extends AbstractSystem {
     const layer = target && target.layer;
     const data = target && target.data;
 
-    // 1. 前回 set した siblings の highlight を解除 (自分が set した ID のみ)
+    // 1. 前回 set した siblings の highlight を解除 (自分が set した ID のみ)。
+    //    ただし select 側がまだ claim している ID は select cleanup に任せるので残す。
     if (this._hoveredRelationSiblings.size > 0) {
       const scene = this.context.systems.gfx && this.context.systems.gfx.scene;
       if (scene) {
@@ -137,6 +150,7 @@ export class MapWithAIService extends AbstractSystem {
           const l = scene.layers && scene.layers.get && scene.layers.get(layerID);
           if (!l || typeof l.unsetClass !== 'function') continue;
           for (const id of this._hoveredRelationSiblings) {
+            if (this._selectedRelationSiblings.has(id)) continue;  // select が claim 中
             l.unsetClass('highlight', id);
           }
         }
@@ -159,6 +173,71 @@ export class MapWithAIService extends AbstractSystem {
       if (!member || member.id === data.id) continue;
       layer.setClass('highlight', member.id);
       this._hoveredRelationSiblings.add(member.id);
+    }
+  }
+
+
+  /**
+   * _onModeChange
+   * Phase 4-B-3: モード遷移時に、select 中の PLATEAU LOD2 building relation
+   * メンバーがあれば同 relation の他 members に 'highlight' を set する。
+   * hover とは別の集合 (`_selectedRelationSiblings`) で追跡し、
+   * cleanup 時に hover が claim している ID は残す。
+   *
+   * @param  {Object|undefined} mode  新しいモードオブジェクト ({ id, ... })
+   */
+  _onModeChange(mode) {
+    const scene = this.context.systems.gfx && this.context.systems.gfx.scene;
+
+    // 1. 前回 set した select siblings の highlight を解除。
+    //    hover が同じ ID をまだ claim していたら、それは hover cleanup に任せる。
+    if (this._selectedRelationSiblings.size > 0) {
+      if (scene) {
+        for (const layerID of ['rapid', 'osm']) {
+          const l = scene.layers && scene.layers.get && scene.layers.get(layerID);
+          if (!l || typeof l.unsetClass !== 'function') continue;
+          for (const id of this._selectedRelationSiblings) {
+            if (this._hoveredRelationSiblings.has(id)) continue;
+            l.unsetClass('highlight', id);
+          }
+        }
+      }
+      this._selectedRelationSiblings.clear();
+    }
+
+    // 2. select 系モードでなければここで終了 (browse / draw / save 等は無視)
+    const modeID = mode && mode.id;
+    if (!modeID || !/^select/.test(modeID)) return;
+
+    // 3. 選択中の entity から PLATEAU LOD2 building relation のメンバーを探す
+    const selectedData = typeof this.context.selectedData === 'function'
+      ? this.context.selectedData()
+      : null;
+    if (!selectedData || typeof selectedData.values !== 'function') return;
+
+    const rapidLayer = scene && scene.layers && scene.layers.get && scene.layers.get('rapid');
+    if (!rapidLayer || typeof rapidLayer.setClass !== 'function') return;
+
+    for (const datum of selectedData.values()) {
+      if (!datum || datum.__service__ !== 'mapwithai') continue;
+
+      const datasetGraph = this.graph(datum.__datasetid__);
+      if (!datasetGraph) continue;
+
+      const info = utilBuildingRelationInfo(datum, datasetGraph);
+      if (!info) continue;
+
+      for (const member of info.relation.members || []) {
+        if (!member || member.id === datum.id) continue;
+        rapidLayer.setClass('highlight', member.id);
+        this._selectedRelationSiblings.add(member.id);
+      }
+    }
+
+    // 4. setClass はそれ自体では再描画を起こさないので、念のため redraw を要求。
+    const gfx = this.context.systems.gfx;
+    if (gfx && typeof gfx.deferredRedraw === 'function' && this._selectedRelationSiblings.size > 0) {
+      gfx.deferredRedraw();
     }
   }
 

--- a/test/browser/services/MapWithAIService.test.js
+++ b/test/browser/services/MapWithAIService.test.js
@@ -689,6 +689,163 @@ describe('MapWithAIService', () => {
         .map(([_, id]) => id);
       expect(unsetIDs).to.include('w_outline');
     });
+
+    it('does not unset highlight on IDs that the select handler still claims', () => {
+      const layer = makeLayerMock();
+      const sceneLayers = new Map([['rapid', layer]]);
+      _service.context.systems.gfx = {
+        scene: { layers: sceneLayers },
+        deferredRedraw() {},
+        immediateRedraw() {},
+      };
+
+      const built = makeBuildingRelationDataset(_service, 'pj');
+      built.part.__service__ = 'mapwithai';
+      built.part.__datasetid__ = 'pj';
+
+      // select 側が outline を claim している状態を再現
+      _service._selectedRelationSiblings.add('w_outline');
+      _service._hoveredRelationSiblings.add('w_outline');
+
+      // hover を外す (cleanup)
+      _service._onHoverchange({ target: null });
+
+      const unsetIDs = layer.getUnsetCalls()
+        .filter(([klass, _]) => klass === 'highlight')
+        .map(([_, id]) => id);
+      expect(unsetIDs).to.not.include('w_outline');
+    });
+  });
+
+
+  describe('#_onModeChange', () => {
+    /**
+     * Phase 4-B-3: select 時に relation の他 members を highlight するハンドラ。
+     * MockContext には selectedData / mode が無いので必要なものを生やして検証する。
+     */
+    function makeLayerMock() {
+      const setCalls = [];
+      const unsetCalls = [];
+      return {
+        setClass(klass, id) { setCalls.push([klass, id]); },
+        unsetClass(klass, id) { unsetCalls.push([klass, id]); },
+        getSetCalls: () => setCalls,
+        getUnsetCalls: () => unsetCalls,
+      };
+    }
+
+    function attachScene(serviceInstance, rapidLayer) {
+      const sceneLayers = new Map([['rapid', rapidLayer]]);
+      serviceInstance.context.systems.gfx = {
+        scene: { layers: sceneLayers },
+        deferredRedraw() {},
+        immediateRedraw() {},
+      };
+    }
+
+    function makeBuildingRelationDataset(serviceInstance, datasetID) {
+      const outline = Rapid.osmWay({ id: 'w_outline', nodes: ['n1'], tags: { building: 'yes' } });
+      const part = Rapid.osmWay({ id: 'w_part', nodes: ['n1'], tags: { 'building:part': 'yes' } });
+      const relation = Rapid.osmRelation({
+        id: 'r_building',
+        tags: { type: 'building', building: 'yes' },
+        members: [
+          { id: outline.id, type: 'way', role: 'outline' },
+          { id: part.id, type: 'way', role: 'part' },
+        ],
+      });
+      const node = Rapid.osmNode({ id: 'n1', loc: [0, 0] });
+      let graph = new Rapid.Graph([node, outline, part, relation]);
+      serviceInstance._datasets[datasetID] = {
+        id: datasetID,
+        graph: graph,
+        tree: null,
+        cache: { inflight: {}, loaded: new Set(), seen: new Set(), seenFirstNodeID: new Set(), splitWays: new Map() },
+      };
+      return { outline, part, relation };
+    }
+
+    it('sets highlight on other relation members when selecting a Plateau member way', () => {
+      const layer = makeLayerMock();
+      attachScene(_service, layer);
+      const built = makeBuildingRelationDataset(_service, 'pj');
+
+      built.part.__service__ = 'mapwithai';
+      built.part.__datasetid__ = 'pj';
+      const selectedData = new Map([[built.part.id, built.part]]);
+      _service.context.selectedData = () => selectedData;
+
+      _service._onModeChange({ id: 'select' });
+
+      const highlightedIDs = layer.getSetCalls()
+        .filter(([klass, _]) => klass === 'highlight')
+        .map(([_, id]) => id);
+      expect(highlightedIDs).to.include('w_outline');
+      expect(highlightedIDs).to.not.include('w_part');
+    });
+
+    it('does nothing when no Plateau feature is selected', () => {
+      const layer = makeLayerMock();
+      attachScene(_service, layer);
+      makeBuildingRelationDataset(_service, 'pj');
+
+      _service.context.selectedData = () => new Map();
+      _service._onModeChange({ id: 'select' });
+
+      expect(layer.getSetCalls()).to.have.lengthOf(0);
+    });
+
+    it('ignores non-select modes (browse, draw, save) and only cleans previous highlights', () => {
+      const layer = makeLayerMock();
+      attachScene(_service, layer);
+      makeBuildingRelationDataset(_service, 'pj');
+
+      // 過去の select で立てた sibling が残っている状態
+      _service._selectedRelationSiblings.add('w_outline');
+
+      _service._onModeChange({ id: 'browse' });
+
+      // browse モードでは select-time highlight をしない
+      expect(layer.getSetCalls()).to.have.lengthOf(0);
+      // 過去 claim 分は unset される
+      const unsetIDs = layer.getUnsetCalls()
+        .filter(([klass, _]) => klass === 'highlight')
+        .map(([_, id]) => id);
+      expect(unsetIDs).to.include('w_outline');
+      expect(_service._selectedRelationSiblings.size).to.eql(0);
+    });
+
+    it('does not unset highlight on IDs that hover still claims', () => {
+      const layer = makeLayerMock();
+      attachScene(_service, layer);
+      makeBuildingRelationDataset(_service, 'pj');
+
+      // hover と select が同じ outline を claim している状態
+      _service._selectedRelationSiblings.add('w_outline');
+      _service._hoveredRelationSiblings.add('w_outline');
+
+      _service._onModeChange({ id: 'browse' });
+
+      const unsetIDs = layer.getUnsetCalls()
+        .filter(([klass, _]) => klass === 'highlight')
+        .map(([_, id]) => id);
+      expect(unsetIDs).to.not.include('w_outline');
+    });
+
+    it('ignores selected entities that do not belong to a building relation', () => {
+      const layer = makeLayerMock();
+      attachScene(_service, layer);
+
+      const solo = Rapid.osmWay({ id: 'w_solo', nodes: [], tags: { building: 'yes' } });
+      _service._datasets.pj_solo = { id: 'pj_solo', graph: new Rapid.Graph([solo]), tree: null, cache: {} };
+      solo.__service__ = 'mapwithai';
+      solo.__datasetid__ = 'pj_solo';
+
+      _service.context.selectedData = () => new Map([[solo.id, solo]]);
+      _service._onModeChange({ id: 'select' });
+
+      expect(layer.getSetCalls()).to.have.lengthOf(0);
+    });
   });
 
 });


### PR DESCRIPTION
## Summary

Phase 4-B-3 — extends the Phase 4-B-2 hover highlight so that the relation member glow also appears while a PLATEAU LOD2 multi-section building part is selected.

Before this change, hovering a building part highlighted its sibling members (so the user could see what "Add Entire Feature" would cascade onto). The moment the user clicked one part, the selection class was applied to that single way but the sibling glow disappeared until the pointer moved back over a member. That made the cascade target invisible exactly when the user was reading the Inspector to decide which button to press.

Now `_onModeChange` re-asserts the highlight on the other relation members whenever a Plateau member is the selected entity, and clears it on the next mode transition.

## Implementation notes

- The handler reuses the existing `'highlight'` class (the same blue glow that `_onHoverchange` sets), so there is no new style to maintain.
- Hover and select track their claims in separate Sets (`_hoveredRelationSiblings` / `_selectedRelationSiblings`). Each cleanup pass skips IDs the other side still claims, so moving the pointer off a sibling no longer cancels the highlight set by selection (and vice-versa).
- `setClass` does not by itself trigger a redraw, so the handler calls `gfx.deferredRedraw()` after claiming siblings.
- Non-select modes (`browse`, `draw`, `save`, ...) fall through to the cleanup-only path, so leaving the selection always releases the glow.

## Test plan

Browser tests (`npm run test:browser`): 595/595 pass. Six new tests cover the new handler and the hover/select cleanup interaction:

- [x] `_onModeChange` sets highlight on siblings when selecting a Plateau member
- [x] `_onModeChange` is a no-op when the selection is empty or non-Plateau
- [x] `_onModeChange` ignores non-select modes but still releases prior claims
- [x] `_onModeChange` does not unset IDs that hover still claims
- [x] `_onModeChange` ignores selected entities outside a building relation
- [x] `_onHoverchange` does not unset IDs that select still claims

Manual verification to run after deploy:

- [ ] At https://rapid.nyampire.info/#map=19.5/33.56928/133.51790&background=Bing (14-part building), click one part — the other 13 stay blue while the click-selected one shows the dashed select halo
- [ ] Move the pointer off the building — the siblings stay highlighted as long as the selection is active
- [ ] Press Esc / click elsewhere — the glow clears
- [ ] Hover a different building's part while one is selected — the previous select highlight persists and the new hover siblings get their own glow
