### PR TITLE
Register PlateauService with RapidSystem (PR #27 hotfix)

### DIFF
--- a/modules/core/RapidSystem.js
+++ b/modules/core/RapidSystem.js
@@ -117,6 +117,7 @@ export class RapidSystem extends AbstractSystem {
     const esri = context.services.esri;
     const mapwithai = context.services.mapwithai;
     const overture = context.services.overture;
+    const plateau = context.services.plateau;
 
     // This code is written in a way that we can work with whatever
     // data-providing services are installed.
@@ -124,6 +125,7 @@ export class RapidSystem extends AbstractSystem {
     if (overture)  services.push(overture);
     if (esri)      services.push(esri);
     if (mapwithai) services.push(mapwithai);
+    if (plateau)   services.push(plateau);
 
     const prerequisites = Promise.all(services.map(service => service.startAsync()));
 


### PR DESCRIPTION
## Summary

Hotfix follow-up to [#27](https://github.com/nyampire/Rapid/pull/27). The PlateauService extraction missed a single registration site in `RapidSystem.startAsync`, which left Plateau buildings invisible on the map even though every other Plateau wiring (service registration in `services/index.js`, layer rendering branch in `PixiLayerRapid.js`, coverage layer service lookup, default dataset IDs) was correct.

## What the bug looks like

After PR #27 merged, the dev server (and by extension production once deployed) would:

- start `PlateauService` successfully (it appears in `context.services.plateau`)
- never call `PlateauService.getAvailableDatasets()` because `RapidSystem.startAsync` iterates a hand-maintained `[esri, mapwithai, overture]` list that didn't include `plateau`
- end up with `plateauJapan` listed in `_addedDatasetIDs` and `_enabledDatasetIDs` but absent from `rapid.catalog` and therefore from `rapid.datasets`
- skip the Plateau dataset entirely in `PixiLayerRapid.render` so the green `#66BB6A` Plateau polygons never appear

## The fix

Two new lines in `modules/core/RapidSystem.js`: read `context.services.plateau` and push it into the same `services` array as the other data-providing services. Matching the pattern that was already added to `PixiLayerRapid.js` in commit `9257535d5`.

## Verification

Local dev server against the Kochi area (`#map=19.5/33.56928/133.51790`):

| Check | Before fix | After fix |
|---|---|---|
| `rapid.datasets.get('plateauJapan')` | undefined | defined, `service: 'plateau'`, `enabled: true` |
| Plateau API tile request | not made | `loaded.size = 1`, `seen.size = 12,966` |
| Plateau buildings on map | absent | green polygons render |
| Phase 4 multi-section Inspector | n/a | hint + 3 buttons render correctly |
| Phase 4-B-3 select highlight | n/a | `_selectedRelationSiblings.size = 5` for a 6-member relation |

PMTilesService / fbRoads were also re-verified in a US area — the cyan ML-road dashes render as upstream intends, so the upstream merge itself is sound.

## Test plan

- [x] `npm run test:browser` still 625/625
- [x] `npm run test:unit` still all passing
- [x] Local dev server: Plateau renders, hover/select highlight works, Inspector 3-buttons show
- [x] Local dev server: fbRoads PMTiles roads render in Vermont
- [ ] Deploy + smoke test on production after merge
