### PR TITLE
Inspector: bind Shift+A to "Add Only This Feature" (closes #26)

### DIFF
--- a/data/core.yaml
+++ b/data/core.yaml
@@ -2648,6 +2648,9 @@ en:
       accept_feature:
         label: Accept the feature
         key: A   # <this key> to Accept a suggested feature
+      accept_only_this_feature:
+        label: Accept only this feature (skip multi-section cascade)
+        key: ⇧A  # <this key> for the Add-Only-This-Feature variant on multi-section buildings
       ignore_feature:
         label: Ignore the feature
         key: D   # <this key> to Ignore a suggested feature

--- a/modules/ui/UiRapidInspector.js
+++ b/modules/ui/UiRapidInspector.js
@@ -6,6 +6,7 @@ import { uiIcon } from './icon.js';
 import { uiFlash } from './flash.js';
 //import { uiRapidFirstEditDialog } from './rapid_first_edit_dialog.js';
 import { uiTooltip } from './tooltip.js';
+import { utilCmd } from '../util/cmd.js';
 import { utilKeybinding } from '../util/keybinding.js';
 import { utilBuildingRelationInfo } from '../util/building_relation.js';
 
@@ -646,6 +647,10 @@ export class UiRapidInspector {
         title = l10n.t('rapid_inspector.option_accept.tooltip');
         shortcut = l10n.t('shortcuts.command.accept_feature.key');
       }
+    } else if (d.key === 'accept_only_this') {
+      title = l10n.t('rapid_inspector.option_accept_only_this.tooltip');
+      // utilCmd.display renders the platform-correct modifier glyph (⇧ / Shift)
+      shortcut = utilCmd.display(this.context, '⇧' + l10n.t('shortcuts.command.accept_feature.key'));
     } else if (d.key === 'ignore') {
       title = l10n.t('rapid_inspector.option_ignore.tooltip');
       shortcut = l10n.t('shortcuts.command.ignore_feature.key');
@@ -685,12 +690,23 @@ export class UiRapidInspector {
     }
 
     const acceptKey = l10n.t('shortcuts.command.accept_feature.key');
+    const acceptOnlyThisKey = utilCmd('⇧' + acceptKey);  // Shift+A
     const ignoreKey = l10n.t('shortcuts.command.ignore_feature.key');
     const moveKey = l10n.t('shortcuts.command.move.key');
     const rotateKey = l10n.t('shortcuts.command.rotate.key');
-    this._keys = [acceptKey, ignoreKey, moveKey, rotateKey];
+    this._keys = [acceptKey, acceptOnlyThisKey, ignoreKey, moveKey, rotateKey];
 
     keybinding.on(acceptKey, this.acceptFeature);
+    // Shift+A → Add Only This Feature. Only meaningful on multi-section
+    // building parts (UiRapidInspector renders the opt-out button only then);
+    // on regular features acceptFeature ignores skipCascade because there is
+    // nothing to cascade in the first place, so the binding is harmless.
+    keybinding.on(acceptOnlyThisKey, (e) => {
+      this.acceptFeature(e, {
+        skipCascade: true,
+        annotationStringID: 'rapid_inspector.option_accept_only_this.annotation'
+      });
+    });
     keybinding.on(ignoreKey, this.ignoreFeature);
     keybinding.on(moveKey, this.moveFeature);
     keybinding.on(rotateKey, this.rotateFeature);


### PR DESCRIPTION
Closes [#26](https://github.com/nyampire/Rapid/issues/26).

## Summary

Adds the missing keyboard shortcut and tooltip for the **"Add Only This Feature"** button that appears on multi-section PLATEAU LOD2 buildings:

| Button | Shortcut | Status before this PR |
|---|---|---|
| Add Entire Feature | `A` | Already bound (default `acceptFeature` path), but only discoverable via tooltip |
| **Add Only This Feature** | **`⇧ Shift + A`** *(new)* | **No shortcut + empty tooltip** |
| Ignore This Feature | `D` | Already bound |

## Why `Shift+A`

`A` is the long-established "accept this Rapid feature" key; making the opt-out variant `Shift+A` keeps the muscle-memory consistent (same finger, modifier toggles whether the relation cascade also fires). `Shift+A` was verified free across the entire shortcut map — every `shortcuts.command.*.key` in `data/l10n/core.en.json` plus all of the `Shift+`-prefixed layer toggles (`Shift+D/O/N/R/M/S/K`) — so there is no contextual collision.

## Implementation

- **[data/core.yaml](data/core.yaml)** — new `shortcuts.command.accept_only_this_feature` entry with `key: ⇧A` so the help panel (`?`) lists it next to the other accept shortcut.
- **[modules/ui/UiRapidInspector.js](modules/ui/UiRapidInspector.js)** — three changes:
  1. Import `utilCmd` to compose the Shift+letter combo.
  2. `_setupKeybinding` binds `utilCmd('⇧A')` to a closure that calls `acceptFeature(e, { skipCascade: true, annotationStringID: 'rapid_inspector.option_accept_only_this.annotation' })`, mirroring the second button's click handler. The new key is also added to `this._keys` so it's cleaned up on rebind.
  3. The tooltip switch in `renderChoice` grows a `d.key === 'accept_only_this'` branch that fills in `option_accept_only_this.tooltip` (already exists in the YAML) and renders the shortcut as a kbd chip via `utilCmd.display(context, '⇧A')`.

## Test plan

- [x] `npm run test:browser` — 625/625 pass.
- [x] `npm run test:unit` — all pass.
- [x] Local dev server, Kochi 14-part building selected:
  - `inspectorKeys = ["A", "⇧A", "D", "M", "R"]` — Shift+A registered alongside the existing keys.
  - Pressing `A` while a building part is selected → `acceptIDs` grows by **7** (outline + 5 parts + relation = full cascade). Mode transitions to `select-osm`.
  - Pressing `Shift+A` while a building part is selected → `acceptIDs` grows by **1** (just the selected way). Mode transitions to `select-osm`. The other relation members stay on the green Rapid layer.
  - Pressing `D` → ignores the feature, behavior unchanged.
  - Hovering "Add Only This Feature" → tooltip renders `Add only the selected way, without the rest of the building structure.` with `⇧ Shift + A` as kbd chips.

## Out of scope

- Inline shortcut hints rendered next to each button label (without requiring hover). Tracked separately if that becomes a recurring ask.
