### PR TITLE
Expand test coverage for PlateauService, RapidSystem, and PixiLayerPlateauCoverage (closes #11)

### DIFF
--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -30,7 +30,10 @@ module.exports = function (config) {
 
     // list of files / patterns to exclude
     exclude: [
-      'test/browser/pixi/*.js',
+      // Legacy Pixi layer tests that require full Rapid context init.
+      // New mock-based Pixi layer tests use the `*.test.js` suffix and are
+      // still picked up via `test/browser/**/*.js`.
+      'test/browser/pixi/PixiLayerMapUI.js',
       // Comment the next line to run the OSM renderer-specific unit test, which right now merely exercise the code.
       // These tests don't actually make any assertions and therefore always succeed.
       'test/browser/renderer/PixiRenderer.js'

--- a/modules/index.js
+++ b/modules/index.js
@@ -19,3 +19,7 @@ export * from './util/index.js';
 export * from './validations/index.js';
 
 export { Context } from './Context.js';
+
+// Direct export for tests that need to construct Pixi layer instances with
+// mock scenes (avoids booting a full Rapid context).
+export { PixiLayerPlateauCoverage } from './pixi/PixiLayerPlateauCoverage.js';

--- a/test/browser/core/RapidSystem.test.js
+++ b/test/browser/core/RapidSystem.test.js
@@ -122,4 +122,84 @@ describe('RapidSystem', () => {
     });
   });
 
+
+  describe('#startAsync defaults', () => {
+    // Verifies the Plateau-focused defaults applied when no `datasets=…`
+    // URL hash param is present. Regression guard for future upstream merges
+    // that touch the default set in RapidSystem.startAsync.
+
+    class MockService {
+      constructor(datasets) { this._datasets = datasets || []; }
+      startAsync() { return Promise.resolve(); }
+      getAvailableDatasets() { return this._datasets; }
+    }
+
+    function makeDataset(id) {
+      return { id, categories: new Set() };
+    }
+
+    function makeContextWithServices(opts = {}) {
+      const ctx = new MockContext();
+      ctx.systems.urlhash = {
+        initialHashParams: new Map(),  // .has('datasets') → false
+        initAsync()   { return Promise.resolve(); },
+        getParam()    { return ''; },
+        setParam()    {},
+        on()          { return this; }
+      };
+      ctx.services.mapwithai = new MockService([makeDataset('fbRoads')]);
+      ctx.services.overture = new MockService([makeDataset('ml-buildings-overture'), makeDataset('esri-buildings')]);
+      ctx.services.plateau = new MockService([makeDataset('plateauJapan')]);
+      if (opts.withDatasetsParam) {
+        ctx.systems.urlhash.initialHashParams = new Map([['datasets', 'foo,bar']]);
+      }
+      return ctx;
+    }
+
+    it('puts plateauJapan in both _addedDatasetIDs and _enabledDatasetIDs by default', () => {
+      const rapid = new Rapid.RapidSystem(makeContextWithServices());
+      return rapid.startAsync().then(() => {
+        expect(rapid._addedDatasetIDs.has('plateauJapan')).to.be.true;
+        expect(rapid._enabledDatasetIDs.has('plateauJapan')).to.be.true;
+      });
+    });
+
+    it('also adds upstream defaults (fbRoads / ml-buildings-overture / esri-buildings) to the menu', () => {
+      const rapid = new Rapid.RapidSystem(makeContextWithServices());
+      return rapid.startAsync().then(() => {
+        expect(rapid._addedDatasetIDs.has('fbRoads')).to.be.true;
+        expect(rapid._addedDatasetIDs.has('ml-buildings-overture')).to.be.true;
+        expect(rapid._addedDatasetIDs.has('esri-buildings')).to.be.true;
+      });
+    });
+
+    it('only enables plateauJapan by default (Japan-focused deployment)', () => {
+      const rapid = new Rapid.RapidSystem(makeContextWithServices());
+      return rapid.startAsync().then(() => {
+        expect(rapid._enabledDatasetIDs.has('fbRoads')).to.be.false;
+        expect(rapid._enabledDatasetIDs.has('ml-buildings-overture')).to.be.false;
+        expect(rapid._enabledDatasetIDs.has('esri-buildings')).to.be.false;
+      });
+    });
+
+    it('does not overwrite the defaults when the URL has a datasets= param', () => {
+      const rapid = new Rapid.RapidSystem(makeContextWithServices({ withDatasetsParam: true }));
+      // Pre-populate as the URL-hash path would
+      rapid._addedDatasetIDs = new Set(['userPicked']);
+      rapid._enabledDatasetIDs = new Set(['userPicked']);
+      return rapid.startAsync().then(() => {
+        // startAsync skipped its default block, user selection survived
+        expect(rapid._addedDatasetIDs.has('plateauJapan')).to.be.false;
+        expect(rapid._addedDatasetIDs.has('userPicked')).to.be.true;
+      });
+    });
+
+    it('catalogs the plateauJapan dataset', () => {
+      const rapid = new Rapid.RapidSystem(makeContextWithServices());
+      return rapid.startAsync().then(() => {
+        expect(rapid.catalog.has('plateauJapan')).to.be.true;
+      });
+    });
+  });
+
 });

--- a/test/browser/pixi/PixiLayerPlateauCoverage.test.js
+++ b/test/browser/pixi/PixiLayerPlateauCoverage.test.js
@@ -1,0 +1,182 @@
+describe('PixiLayerPlateauCoverage', () => {
+  // Mock-based unit test for the Plateau coverage Pixi layer. Avoids
+  // booting a full Rapid context / real Pixi by stubbing the AbstractLayer
+  // dependencies (`scene.gfx`, `scene.context`) just enough to exercise
+  // the zoom guard, the once-per-instance fetch, and graceful degradation.
+  //
+  // Issue #11: previously there was no test infrastructure for Pixi layers
+  // in this fork. This file establishes a mock-based pattern other layer
+  // tests can follow.
+
+  function makeService(opts = {}) {
+    const calls = { loadCoverage: 0 };
+    return {
+      loadCoverage() {
+        calls.loadCoverage++;
+        return Promise.resolve(opts.coverageResolves ?? null);
+      },
+      _coverageData: opts.coverageData ?? null,
+      _calls: calls
+    };
+  }
+
+  function makeScene(opts = {}) {
+    const gfx = {
+      scene: null,            // back-pointer is set below
+      deferredRedrawCount: 0,
+      deferredRedraw() { gfx.deferredRedrawCount++; },
+      immediateRedraw() {}
+    };
+    const context = {
+      services: opts.services ?? {},
+      systems: { gfx: gfx }
+    };
+    const scene = {
+      gfx: gfx,
+      context: context,
+      groups: new Map([['basemap', null]])
+    };
+    gfx.scene = scene;
+    return scene;
+  }
+
+  function makeLayer(serviceOpts) {
+    const scene = makeScene({
+      services: { plateau: serviceOpts === null ? undefined : makeService(serviceOpts) }
+    });
+    const layer = new Rapid.PixiLayerPlateauCoverage(scene, 'plateau-coverage');
+    // Stub the actual feature rendering so we don't need Pixi
+    layer._renderFeaturesCalls = 0;
+    layer._renderFeatures = () => { layer._renderFeaturesCalls++; };
+    return { layer, scene, service: scene.context.services.plateau };
+  }
+
+
+  describe('#supported', () => {
+    it('returns true when plateau service is registered', () => {
+      const { layer } = makeLayer({});
+      expect(layer.supported).to.be.true;
+    });
+
+    it('returns false when plateau service is missing', () => {
+      const { layer } = makeLayer(null);
+      expect(layer.supported).to.be.false;
+    });
+  });
+
+
+  describe('#render zoom range', () => {
+    it('does nothing when zoom is below MINZOOM (5)', () => {
+      const { layer, service } = makeLayer({});
+      layer.render(1, null, 4);
+      expect(service._calls.loadCoverage).to.eql(0);
+      expect(layer._renderFeaturesCalls).to.eql(0);
+    });
+
+    it('does nothing when zoom is above MAXZOOM (14)', () => {
+      const { layer, service } = makeLayer({});
+      layer.render(1, null, 15);
+      expect(service._calls.loadCoverage).to.eql(0);
+      expect(layer._renderFeaturesCalls).to.eql(0);
+    });
+
+    it('renders within the zoom range when data is cached', () => {
+      const fc = { type: 'FeatureCollection', features: [{ id: 'a', geometry: { type: 'Polygon', coordinates: [] } }] };
+      const { layer } = makeLayer({ coverageData: fc });
+      layer.render(1, null, 10);
+      expect(layer._renderFeaturesCalls).to.eql(1);
+    });
+
+    it('handles MINZOOM and MAXZOOM as inclusive bounds', () => {
+      const fc = { type: 'FeatureCollection', features: [] };
+      const { layer } = makeLayer({ coverageData: fc });
+      layer.render(1, null, 5);    // MINZOOM inclusive
+      layer.render(2, null, 14);   // MAXZOOM inclusive
+      // Both calls should pass the zoom gate; _renderFeatures is invoked
+      // (even with empty features, the function is called, then iterates over nothing).
+      expect(layer._renderFeaturesCalls).to.eql(2);
+    });
+  });
+
+
+  describe('#render when disabled', () => {
+    it('does nothing when layer is disabled', () => {
+      const { layer, service } = makeLayer({});
+      layer._enabled = false;
+      layer.render(1, null, 10);
+      expect(service._calls.loadCoverage).to.eql(0);
+      expect(layer._renderFeaturesCalls).to.eql(0);
+    });
+  });
+
+
+  describe('#render with missing service', () => {
+    it('returns early when context.services.plateau is undefined', () => {
+      const { layer } = makeLayer(null);
+      // No throw; just an early return
+      expect(() => layer.render(1, null, 10)).to.not.throw();
+      expect(layer._renderFeaturesCalls).to.eql(0);
+    });
+  });
+
+
+  describe('#render fetch lifecycle', () => {
+    it('calls service.loadCoverage exactly once on first in-range render', () => {
+      const { layer, service } = makeLayer({});
+      layer.render(1, null, 10);
+      expect(service._calls.loadCoverage).to.eql(1);
+      expect(layer._fetched).to.be.true;
+    });
+
+    it('does not call loadCoverage again on subsequent renders (fetch-once)', () => {
+      const { layer, service } = makeLayer({});
+      layer.render(1, null, 10);
+      layer.render(2, null, 10);
+      layer.render(3, null, 12);
+      expect(service._calls.loadCoverage).to.eql(1);
+    });
+
+    it('triggers a deferredRedraw when loadCoverage resolves with data', async () => {
+      const fc = { type: 'FeatureCollection', features: [] };
+      const { layer, scene } = makeLayer({ coverageResolves: fc });
+      layer.render(1, null, 10);
+      // wait one microtask + macrotask for the .then() to fire
+      await Promise.resolve();
+      await new Promise(r => { setTimeout(r, 0); });
+      expect(scene.gfx.deferredRedrawCount).to.be.greaterThan(0);
+    });
+
+    it('does NOT trigger deferredRedraw when loadCoverage resolves with null (graceful)', async () => {
+      const { layer, scene } = makeLayer({ coverageResolves: null });
+      layer.render(1, null, 10);
+      await Promise.resolve();
+      await new Promise(r => { setTimeout(r, 0); });
+      expect(scene.gfx.deferredRedrawCount).to.eql(0);
+    });
+  });
+
+
+  describe('#render data handling', () => {
+    it('skips _renderFeatures when service has no _coverageData', () => {
+      const { layer } = makeLayer({});  // coverageData stays null
+      layer.render(1, null, 10);
+      expect(layer._renderFeaturesCalls).to.eql(0);
+    });
+
+    it('skips _renderFeatures when _coverageData has no features array', () => {
+      const { layer } = makeLayer({ coverageData: { type: 'FeatureCollection' } });
+      layer.render(1, null, 10);
+      expect(layer._renderFeaturesCalls).to.eql(0);
+    });
+
+    it('invokes _renderFeatures with the features array when data is present', () => {
+      const feats = [{ id: 'a', geometry: { type: 'Polygon', coordinates: [] } }];
+      const { layer } = makeLayer({ coverageData: { type: 'FeatureCollection', features: feats } });
+      let receivedFeatures = null;
+      layer._renderFeatures = (frame, vp, zoom, features) => { receivedFeatures = features; };
+      layer.render(1, null, 10);
+      expect(receivedFeatures).to.equal(feats);
+    });
+  });
+
+});

--- a/test/browser/services/PlateauService.test.js
+++ b/test/browser/services/PlateauService.test.js
@@ -652,4 +652,124 @@ describe('PlateauService', () => {
     });
   });
 
+
+  describe('#loadCoverage', () => {
+    // Coverage endpoint is derived from PLATEAU_API_URL by replacing
+    // `/buildings(?…)?` with `/coverage`. The default URL points to
+    // production; tests use the URL-hash override (#plateau_api_url=…) to
+    // route the request through a localhost path that fetchMock controls.
+    const FAKE_BUILDINGS_URL = 'http://test.invalid/api/mapwithai/buildings';
+    const FAKE_COVERAGE_URL = 'http://test.invalid/api/mapwithai/coverage';
+    const DEFAULT_COVERAGE_URL_RE = /rapid\.nyampire\.info\/api\/mapwithai\/coverage/;
+
+    let _originalHash;
+
+    beforeEach(() => {
+      fetchMock.removeRoutes().clearHistory();
+      _originalHash = window.location.hash;
+      // Default: no URL override → service hits the production-shaped URL,
+      // which we mock with a regex so DNS / TLS never matter.
+      window.history.replaceState(null, '', window.location.pathname);
+    });
+
+    afterEach(() => {
+      fetchMock.removeRoutes().clearHistory();
+      window.history.replaceState(null, '', window.location.pathname + _originalHash);
+    });
+
+    function mockCoverage(routeMatcher, body) {
+      fetchMock.route(routeMatcher, {
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+
+    it('fetches and caches the coverage FeatureCollection on first call', async () => {
+      const fc = { type: 'FeatureCollection', features: [] };
+      mockCoverage(DEFAULT_COVERAGE_URL_RE, fc);
+
+      const result = await _service.loadCoverage();
+
+      expect(result).to.eql(fc);
+      expect(_service._coverageData).to.eql(fc);
+      expect(fetchMock.callHistory.calls().length).to.eql(1);
+    });
+
+    it('returns cached data without a second fetch on subsequent calls', async () => {
+      const fc = { type: 'FeatureCollection', features: [{ id: 'a' }] };
+      mockCoverage(DEFAULT_COVERAGE_URL_RE, fc);
+
+      const first = await _service.loadCoverage();
+      const second = await _service.loadCoverage();
+
+      expect(second).to.equal(first);  // same reference (cached)
+      expect(fetchMock.callHistory.calls().length).to.eql(1);
+    });
+
+    it('coalesces concurrent inflight calls into a single fetch', async () => {
+      const fc = { type: 'FeatureCollection', features: [] };
+      mockCoverage(DEFAULT_COVERAGE_URL_RE, fc);
+
+      const [a, b, c] = await Promise.all([
+        _service.loadCoverage(),
+        _service.loadCoverage(),
+        _service.loadCoverage()
+      ]);
+
+      expect(a).to.eql(fc);
+      expect(b).to.eql(fc);
+      expect(c).to.eql(fc);
+      expect(fetchMock.callHistory.calls().length).to.eql(1);
+    });
+
+    it('returns null on fetch failure without throwing (graceful degradation)', async () => {
+      fetchMock.route(DEFAULT_COVERAGE_URL_RE, { status: 500, body: 'oops' });
+
+      const result = await _service.loadCoverage();
+
+      expect(result).to.be.null;
+      expect(_service._coverageData).to.be.null;
+      // Inflight promise must reset on failure so a later call can retry
+      expect(_service._coveragePromise).to.be.null;
+    });
+
+    it('returns null when the response shape is not a FeatureCollection', async () => {
+      mockCoverage(DEFAULT_COVERAGE_URL_RE, { type: 'Feature' });  // wrong type
+
+      const result = await _service.loadCoverage();
+
+      expect(result).to.be.null;
+      expect(_service._coverageData).to.be.null;
+    });
+
+    it('honors the #plateau_api_url hash override when building the coverage URL', async () => {
+      window.history.replaceState(null, '', window.location.pathname + '#plateau_api_url=' + FAKE_BUILDINGS_URL);
+      const fc = { type: 'FeatureCollection', features: [{ id: 'override' }] };
+      mockCoverage(FAKE_COVERAGE_URL, fc);
+
+      const result = await _service.loadCoverage();
+
+      expect(result).to.eql(fc);
+      const lastUrl = fetchMock.callHistory.lastCall().url;
+      expect(lastUrl).to.eql(FAKE_COVERAGE_URL);
+    });
+
+    it('retries after a previous failure clears the inflight promise', async () => {
+      // First call fails …
+      fetchMock.route(DEFAULT_COVERAGE_URL_RE, { status: 500 });
+      const firstResult = await _service.loadCoverage();
+      expect(firstResult).to.be.null;
+
+      // … second call sees a healthy response (re-route)
+      fetchMock.removeRoutes().clearHistory();
+      const fc = { type: 'FeatureCollection', features: [] };
+      mockCoverage(DEFAULT_COVERAGE_URL_RE, fc);
+      const secondResult = await _service.loadCoverage();
+
+      expect(secondResult).to.eql(fc);
+      expect(_service._coverageData).to.eql(fc);
+    });
+  });
+
 });


### PR DESCRIPTION
Closes [#11](https://github.com/nyampire/Rapid/issues/11).

## Scope

The issue listed three coverage gaps. Two were never filled, and one was filled in passing during PR #27 (when `PlateauService` was extracted). This PR completes the remaining work.

| Issue item | Status before | Status after |
|---|---|---|
| `MapWithAIService.js` XML parse / conflation / hover / select tests | **done in [#27](https://github.com/nyampire/Rapid/pull/27)** — moved to `PlateauService.test.js`, ~600 lines, 4 describe blocks | unchanged |
| `loadCoverage()` cache / inflight / graceful / URL override tests | not started | **+7 tests** in `PlateauService.test.js` |
| `PixiLayerPlateauCoverage` tests | not started, no test infrastructure | **+15 tests** in new `test/browser/pixi/PixiLayerPlateauCoverage.test.js`, with reusable mock-based pattern |
| `RapidSystem` plateauJapan-default regression guard | not started | **+5 tests** in `RapidSystem.test.js` |

## Why this matters now

PR [#28](https://github.com/nyampire/Rapid/pull/28) was a hotfix for exactly the kind of regression Issue #11 anticipated: `plateauJapan` was silently dropped from `RapidSystem.startAsync` during the upstream 2.5.7 merge because `RapidSystem.js` didn't have a test covering the default-dataset block. The new `#startAsync defaults` describe in this PR locks that behavior down so the same mistake can't recur on the next upstream merge.

## Implementation notes

### Test infrastructure for Pixi layers (new)

The Issue called out that the fork had no mock-based Pixi-layer test infrastructure. The existing `test/browser/pixi/PixiLayerMapUI.js` boots a full Rapid context and a DOM container, which is too heavy for layer-internals unit tests.

This PR establishes a lighter pattern:

- `karma.conf.cjs` exclusion narrowed from `test/browser/pixi/*.js` to just `test/browser/pixi/PixiLayerMapUI.js` (the legacy file). New `*.test.js` files under `test/browser/pixi/` are now picked up automatically.
- `modules/index.js` adds a direct export for `PixiLayerPlateauCoverage` so tests can construct the layer with a stub scene without booting a full Rapid context.
- `PixiLayerPlateauCoverage.test.js` ships a `makeService` / `makeScene` / `makeLayer` helper trio that future layer tests can copy.

The pattern lets us test:

- the `supported` getter against the presence/absence of the relevant service
- `render()` zoom-range guards (MINZOOM 5, MAXZOOM 14 inclusive)
- the disabled-layer and missing-service no-op paths
- the fetch-once lifecycle (`loadCoverage` called exactly once, `deferredRedraw` only fired on non-null result)
- data-handling early returns (`_coverageData` missing, `features` missing)

…all without involving Pixi rendering.

### Mock services for RapidSystem.startAsync

`RapidSystem.startAsync` iterates `context.services.{overture, esri, mapwithai, plateau}` to build the dataset catalog and then applies fork-specific defaults. The tests pass minimal `MockService` instances that return `[{ id, categories: new Set() }]` from `getAvailableDatasets()` so the iteration finishes without booting the real Pixi / UI / network stacks.

## Test plan

- [x] `npm run test:browser` — 652/652 pass (was 625 on main; +27 from this PR).
- [x] `npm run test:unit` — 1196/0 pass.
- [ ] Verify no regression on the next `git merge upstream/main` by ensuring `_addedDatasetIDs` / `_enabledDatasetIDs` defaults still satisfy the new tests.
