### PR TITLE
PixiLayerPlateauCoverage: retry after a failed coverage fetch (review fix for #30)

### DIFF
--- a/modules/pixi/PixiLayerPlateauCoverage.js
+++ b/modules/pixi/PixiLayerPlateauCoverage.js
@@ -31,8 +31,9 @@ export class PixiLayerPlateauCoverage extends AbstractLayer {
    */
   constructor(scene, layerID) {
     super(scene, layerID);
-    this._enabled = true;          // Default ON
-    this._fetched = false;         // True after we've attempted the initial fetch
+    this._enabled = true;             // Default ON
+    this._fetched = false;            // True after coverage has loaded successfully
+    this._fetchInProgress = false;    // True while a fetch is inflight (prevents storm)
   }
 
 
@@ -68,14 +69,22 @@ export class PixiLayerPlateauCoverage extends AbstractLayer {
     const service = this.context.services.plateau;
     if (!service) return;
 
-    // Trigger fetch once. Promise resolves with FeatureCollection or null.
-    // Until it resolves, we have nothing to draw — re-render will pick it up.
-    if (!this._fetched) {
-      this._fetched = true;
+    // Trigger fetch lazily. Promise resolves with FeatureCollection or null.
+    // - `_fetchInProgress` blocks concurrent fetches from successive renders
+    //   (one render → one inflight request → service-side coalesce handles
+    //   any extras anyway, but skipping the .then() noise here is cheaper).
+    // - `_fetched` flips to true ONLY on successful load, so a transient
+    //   failure (network blip, 500) can be retried by the next render.
+    if (!this._fetched && !this._fetchInProgress) {
+      this._fetchInProgress = true;
       service.loadCoverage().then(data => {
+        this._fetchInProgress = false;
         if (data) {
+          this._fetched = true;
           this.context.systems.gfx.deferredRedraw();
         }
+        // On null (failure or invalid shape), `_fetched` stays false so a
+        // future render will retry.
       });
     }
 

--- a/test/browser/pixi/PixiLayerPlateauCoverage.test.js
+++ b/test/browser/pixi/PixiLayerPlateauCoverage.test.js
@@ -10,14 +10,26 @@ describe('PixiLayerPlateauCoverage', () => {
 
   function makeService(opts = {}) {
     const calls = { loadCoverage: 0 };
+    // Caller can pass a static value (default) or a function that returns
+    // the value for each call. The function form lets a single test vary
+    // the result across successive calls (e.g. fail-then-succeed).
+    const resolver = typeof opts.coverageResolves === 'function'
+      ? opts.coverageResolves
+      : () => (opts.coverageResolves ?? null);
     return {
       loadCoverage() {
         calls.loadCoverage++;
-        return Promise.resolve(opts.coverageResolves ?? null);
+        return Promise.resolve(resolver(calls.loadCoverage));
       },
       _coverageData: opts.coverageData ?? null,
       _calls: calls
     };
+  }
+
+  // Wait one microtask + one macrotask so a .then() chained off a
+  // synchronously-started Promise has run before the assertion fires.
+  function flushPromises() {
+    return new Promise(r => { setTimeout(r, 0); });
   }
 
   function makeScene(opts = {}) {
@@ -121,18 +133,38 @@ describe('PixiLayerPlateauCoverage', () => {
 
 
   describe('#render fetch lifecycle', () => {
-    it('calls service.loadCoverage exactly once on first in-range render', () => {
-      const { layer, service } = makeLayer({});
+    it('marks fetch as in-progress synchronously and only flips _fetched on a successful result', async () => {
+      const fc = { type: 'FeatureCollection', features: [] };
+      const { layer, service } = makeLayer({ coverageResolves: fc });
       layer.render(1, null, 10);
+      // Synchronously: in-progress flag set, _fetched still false (Promise pending).
       expect(service._calls.loadCoverage).to.eql(1);
+      expect(layer._fetchInProgress).to.be.true;
+      expect(layer._fetched).to.be.false;
+      // After the Promise resolves: _fetched true, in-progress cleared.
+      await flushPromises();
       expect(layer._fetched).to.be.true;
+      expect(layer._fetchInProgress).to.be.false;
     });
 
-    it('does not call loadCoverage again on subsequent renders (fetch-once)', () => {
-      const { layer, service } = makeLayer({});
+    it('does not call loadCoverage again on subsequent renders after a successful fetch', async () => {
+      const fc = { type: 'FeatureCollection', features: [] };
+      const { layer, service } = makeLayer({ coverageResolves: fc });
       layer.render(1, null, 10);
+      await flushPromises();             // first fetch succeeds
       layer.render(2, null, 10);
       layer.render(3, null, 12);
+      expect(service._calls.loadCoverage).to.eql(1);
+    });
+
+    it('coalesces concurrent renders to a single inflight fetch', () => {
+      const fc = { type: 'FeatureCollection', features: [] };
+      const { layer, service } = makeLayer({ coverageResolves: fc });
+      // Three renders fire back-to-back before the first Promise has resolved.
+      layer.render(1, null, 10);
+      layer.render(2, null, 10);
+      layer.render(3, null, 10);
+      // Only the first render initiates a fetch.
       expect(service._calls.loadCoverage).to.eql(1);
     });
 
@@ -140,18 +172,61 @@ describe('PixiLayerPlateauCoverage', () => {
       const fc = { type: 'FeatureCollection', features: [] };
       const { layer, scene } = makeLayer({ coverageResolves: fc });
       layer.render(1, null, 10);
-      // wait one microtask + macrotask for the .then() to fire
-      await Promise.resolve();
-      await new Promise(r => { setTimeout(r, 0); });
+      await flushPromises();
       expect(scene.gfx.deferredRedrawCount).to.be.greaterThan(0);
     });
 
     it('does NOT trigger deferredRedraw when loadCoverage resolves with null (graceful)', async () => {
       const { layer, scene } = makeLayer({ coverageResolves: null });
       layer.render(1, null, 10);
-      await Promise.resolve();
-      await new Promise(r => { setTimeout(r, 0); });
+      await flushPromises();
       expect(scene.gfx.deferredRedrawCount).to.eql(0);
+    });
+
+    it('retries on the next render after a failed (null) fetch', async () => {
+      // 1st call → null (failure), 2nd+ calls → success.
+      const fc = { type: 'FeatureCollection', features: [] };
+      const { layer, scene, service } = makeLayer({
+        coverageResolves: (callCount) => (callCount === 1 ? null : fc)
+      });
+      layer.render(1, null, 10);
+      await flushPromises();
+      expect(service._calls.loadCoverage).to.eql(1);
+      expect(layer._fetched).to.be.false;            // failure did NOT lock us out
+      expect(layer._fetchInProgress).to.be.false;    // inflight cleared so retry can run
+
+      // Next render: retry happens.
+      layer.render(2, null, 10);
+      await flushPromises();
+      expect(service._calls.loadCoverage).to.eql(2);
+      expect(layer._fetched).to.be.true;             // now succeeded
+      expect(scene.gfx.deferredRedrawCount).to.be.greaterThan(0);
+    });
+
+    it('does not re-fetch while the first call is still inflight, even across many renders', async () => {
+      // Hold the Promise un-resolved so we can observe synchronous behavior.
+      let resolveFn;
+      const heldPromise = new Promise(r => { resolveFn = r; });
+      const service = {
+        loadCoverage() { service._calls.loadCoverage++; return heldPromise; },
+        _coverageData: null,
+        _calls: { loadCoverage: 0 }
+      };
+      const scene = makeScene({ services: { plateau: service } });
+      const layer = new Rapid.PixiLayerPlateauCoverage(scene, 'plateau-coverage');
+      layer._renderFeatures = () => {};
+
+      layer.render(1, null, 10);
+      layer.render(2, null, 10);
+      layer.render(3, null, 10);
+      expect(service._calls.loadCoverage).to.eql(1);   // coalesced while inflight
+      expect(layer._fetchInProgress).to.be.true;
+
+      // Resolve and let the .then run.
+      resolveFn({ type: 'FeatureCollection', features: [] });
+      await flushPromises();
+      expect(layer._fetched).to.be.true;
+      expect(layer._fetchInProgress).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Summary

Critical-review follow-up to [#30](https://github.com/nyampire/Rapid/pull/30). Fixes a behavior bug in `PixiLayerPlateauCoverage` and tightens the tests that previously hid it.

## The bug

```js
// before
if (!this._fetched) {
  this._fetched = true;                  // set BEFORE the fetch starts
  service.loadCoverage().then(data => {
    if (data) gfx.deferredRedraw();
  });
}
```

`_fetched` flipped to `true` synchronously, _before_ the Promise resolved. If the first fetch then resolved to `null` (network blip, DNS issue, 5xx, malformed payload — any of the failure modes `PlateauService.loadCoverage` returns null for), the layer was permanently locked out of trying again — even though the service-side cache was clean and ready for another attempt. The user had to reload the page to see coverage.

PR #30 had a test that exercised exactly this case and asserted it as the correct behavior:

```js
it('does NOT trigger deferredRedraw when loadCoverage resolves with null (graceful)', async () => {
  layer.render(1, null, 10);
  // …
  expect(scene.gfx.deferredRedrawCount).to.eql(0);
});
```

The assertion was technically true but it only covered the immediate frame. It said nothing about whether the layer ever retried — and so the bug shipped.

## The fix

Two flags instead of one:

| Flag | When set | When cleared |
|---|---|---|
| `_fetchInProgress` | synchronously, before calling `loadCoverage` | inside `.then()`, always |
| `_fetched` | inside `.then()`, **only if `data` is truthy** | never (stays once true) |

`_fetchInProgress` is the new storm-protection knob. `_fetched` is now strictly a "success has happened" flag. On failure both end up clear, so the next render gets to try again. Retry-rate is still naturally bounded by `PlateauService.loadCoverage`'s service-side inflight-Promise coalesce, so a persistent outage doesn't fire a fetch per frame.

## Tests rewritten

The "#render fetch lifecycle" describe is now five tests that actually exercise the contract:

- synchronous `_fetchInProgress` set, `_fetched` only flips after the success path
- no re-fetch after a successful render
- back-to-back renders coalesce to a single fetch (synchronous chain)
- **retries on the next render after a null/failed fetch** ← the new regression guard
- a held un-resolved Promise across many synchronous renders still yields exactly one service call (verifies inflight gating, not the success-then-skip path)

The helper `makeService` now also accepts `coverageResolves` as a function `(callCount) => value` so a single test can flip behavior between calls.

## Test plan

- [x] `npm run test:browser` — 655/655 pass.
- [x] `npm run test:unit` — 1196/0 pass.
- [x] `npm run lint` — 0 errors (warnings unchanged).
- [x] Local dev server at zoom 10 hitting the production Plateau API: `loadCoverage` returns 142 features, `layer._fetched === true`, `layer._fetchInProgress === false`. No regression on the success path.
- [ ] After deploy: confirm in a real "first request times out, second succeeds" scenario (hard to script).
