### PR TITLE
fix(plateau): 大きな OSM 建物内の極小 Plateau 候補を除外する

### DIFF
--- a/modules/core/lib/HeightTransferMatcher.js
+++ b/modules/core/lib/HeightTransferMatcher.js
@@ -76,7 +76,16 @@ export function findCandidates({
     let state;
     let tagStates;
 
-    if (ratio < AREA_RATIO_MIN || ratio > AREA_RATIO_MAX) {
+    // A Plateau outline far SMALLER than the OSM building it sits in is an
+    // ancillary structure Plateau models as its own `building` -- a rooftop
+    // stair enclosure, a shed. Its height describes that structure, not the
+    // building, so transferring it would be wrong and flagging it is only
+    // noise (observed: 7-9 m2 outlines inside a 214 m2 OSM building). Drop it.
+    if (ratio < AREA_RATIO_MIN) continue;
+
+    if (ratio > AREA_RATIO_MAX) {
+      // Plateau outline far LARGER than the OSM building: block-level or
+      // partial OSM mapping under one Plateau outline. Worth a human look.
       state = 'AREA_MISMATCH';
       tagStates = analyzeTagStates(osm, outline);
     } else {

--- a/test/browser/core/lib/HeightTransferMatcher.test.js
+++ b/test/browser/core/lib/HeightTransferMatcher.test.js
@@ -93,12 +93,31 @@ describe('HeightTransferMatcher', () => {
       expect(out[0].state).to.equal('CONFLICT');
     });
 
-    it('returns AREA_MISMATCH when area ratio is outside 0.5..2.0', () => {
-      // OSM building is 10x wider than Plateau
+    it('skips a Plateau outline far smaller than the OSM building (sub-structure)', () => {
+      // OSM building is 10x wider than the Plateau outline -> ratio ~0.1.
+      // In real data this is a rooftop stair enclosure / shed that Plateau
+      // carries as its own `building`, sitting inside a much larger OSM
+      // footprint. Transferring its height would be wrong, and flagging it
+      // is just noise, so it produces no candidate at all.
       const bigOsm = [[139.750, 35.679], [139.760, 35.679],
                       [139.760, 35.680], [139.750, 35.680], [139.750, 35.679]];
       const p = outline('p1', SQR, { height: '12' }, SQR_CENTER);
       const o = osmBuilding('o1', bigOsm);
+      const out = Rapid.findCandidates({
+        plateauEntities: [p], osmEntities: [o],
+        transferredIDs: new Set(), acceptIDs: new Set(), ignoreIDs: new Set()
+      });
+      expect(out).to.eql([]);
+    });
+
+    it('returns AREA_MISMATCH when the Plateau outline is far larger than the OSM building', () => {
+      // Plateau outline is ~10x wider than the OSM building -> ratio ~10.
+      // This is the reviewable case: OSM has block-level or partial mapping
+      // under one large Plateau outline, so a human should look at it.
+      const bigPlateau = [[139.750, 35.679], [139.760, 35.679],
+                          [139.760, 35.680], [139.750, 35.680], [139.750, 35.679]];
+      const p = outline('p1', bigPlateau, { height: '12' }, SQR_CENTER);
+      const o = osmBuilding('o1', SQR);
       const out = Rapid.findCandidates({
         plateauEntities: [p], osmEntities: [o],
         transferredIDs: new Set(), acceptIDs: new Set(), ignoreIDs: new Set()


### PR DESCRIPTION
Plateau は塔屋や物置といった付属構造物を `building:part` ではなく独立した `building=yes` として持っています。そのため既存の `building:part` フィルタでは弾けず、代表点が大きな OSM 建物の内側に落ちて `AREA_MISMATCH` の候補として表示されていました。実測では 214 m² の OSM 建物の中に 7 m² (h=10.3) と 9 m² (h=2.95) の候補が出て、本来の 222 m² のマッチと合わせて 3 つのドットが並ぶ状態でした。

これらの高さは付属構造物自身の高さであって建物の高さではないため、転記すると誤りになります。フラグとして出す価値もないノイズなので、面積比 0.5 未満の候補は完全に除外します。

あわせて `AREA_MISMATCH` は面積比 2.0 超、つまり Plateau の外形が OSM 建物よりずっと大きい場合だけに限定しました。これは OSM 側で建物の一部しか描かれていないことを示唆するケースで、人間が確認する価値があるためフラグとして残します。

テスト 724 件グリーン。
