### PR TITLE
docs: Plateau ガイドを実装に追従させ、英語版と日本語版を用意する

### DIFF
--- a/PLATEAU.ja.md
+++ b/PLATEAU.ja.md
@@ -1,0 +1,225 @@
+# Plateau インポート機能 開発者ガイド
+
+*English version: [PLATEAU.md](PLATEAU.md)*
+
+Plateau の建築物データを OpenStreetMap にインポートする作業を支援するために
+Rapid へ追加した機能について、実装と開発の進め方をまとめたものです。
+
+このフォークが扱うのは **Plateau の建築物データのみ**です。Plateau には橋梁・
+トンネル・植生などのカテゴリもありますが、それらは対象外です。
+
+関連リポジトリは 3 つあります。
+
+| リポジトリ | 役割 |
+|---|---|
+| [nyampire/Rapid](https://github.com/nyampire/Rapid) | エディタ（このリポジトリ） |
+| [nyampire/rapid_plateau_api](https://github.com/nyampire/rapid_plateau_api) | 建物データを配信するバックエンド |
+| [nyampire/rapid_plateau_dashboard](https://github.com/nyampire/rapid_plateau_dashboard) | インポート進捗の可視化 |
+
+## アーキテクチャ概要
+
+Plateau データは `PlateauService`（`modules/services/PlateauService.js`）が
+取得・管理します。
+
+- **データセットID**: `plateauJapan`
+- **データ形式**: OSM XML
+- **タイルズームレベル**: 16 以上
+
+Plateau 固有の処理（リレーション対応、conflation、カバレッジ、ハイライト）は、
+upstream の MapWithAI / PMTiles まわりから独立させてあります。
+`git merge upstream/main` で Plateau 側が巻き込まれないようにするためです。
+
+このサービスが出すデータには `__service__ = 'plateau'` が付きます。
+
+### Plateau 固有のモジュール
+
+| モジュール | 役割 |
+|---|---|
+| `modules/services/PlateauService.js` | API 取得、リレーション組み立て、conflation、カバレッジ |
+| `modules/pixi/PixiLayerPlateauCoverage.js` | 対応エリアの塗りつぶし表示 |
+| `modules/pixi/PixiLayerHeightTransfer.js` | タグ転記の候補ドット描画 |
+| `modules/modes/HeightTransferMode.js` | タグ転記モード本体。候補の再計算と適用 |
+| `modules/core/lib/HeightTransferMatcher.js` | Plateau 外形と OSM 建物の突き合わせ |
+| `modules/ui/sections/plateau_tags.js` | エンティティエディタ内のタグ転記セクション |
+| `modules/actions/transfer_plateau_tags.js` | タグ追加の編集アクション |
+
+## Plateau API
+
+### 本番URL
+
+```
+https://rapid.nyampire.info/api/mapwithai/buildings
+```
+
+`PlateauService.js` の `PLATEAU_API_URL` 定数にハードコードされています。
+
+### ローカル開発時のAPI切り替え
+
+URLハッシュパラメータでAPIエンドポイントをランタイムで上書きできます。
+
+```
+http://127.0.0.1:8080/#plateau_api_url=http://localhost:8000/api/mapwithai/buildings
+```
+
+ローカルで Plateau API サーバー（`rapid_plateau_api`）を起動し、上記のように
+アクセスすることで、本番APIの代わりにローカルAPIを使用できます。
+
+## URLハッシュパラメータ一覧
+
+| パラメータ | 説明 | 例 |
+|---|---|---|
+| `plateau_api_url` | Plateau APIエンドポイントの上書き | `#plateau_api_url=http://localhost:8000/api/mapwithai/buildings` |
+| `plateau_conflation` | クライアントサイドconflationの無効化 | `#plateau_conflation=false` |
+
+## タグ転記（height / ele / building:levels）
+
+Plateau が持つ高さ情報を、既存の OSM 建物へ転記する機能です。
+ツールバーの「タグ転記モード」で有効になります。
+
+対象タグは `height` / `ele` / `building:levels` の 3 つです。
+
+### 候補の判定
+
+`HeightTransferMatcher.findCandidates()` が、Plateau 外形の代表点
+（API が返す `representative_point`）を含む OSM 建物を探します。含む建物が
+ちょうど 1 つのときだけ候補になります。0 個や複数なら曖昧なので対象外です。
+
+そのうえで面積比（Plateau 外形 ÷ OSM 建物）を見ます。
+
+| 面積比 | 扱い |
+|---|---|
+| 0.5 未満 | 候補から除外 |
+| 0.5〜2.0 | タグの状態で判定（下表） |
+| 2.0 超 | `AREA_MISMATCH` |
+
+0.5 未満を捨てるのは、Plateau が塔屋や物置といった付属構造物を
+`building:part` ではなく独立した `building=yes` として持つためです。
+代表点が大きな OSM 建物の内側に落ちるので、除外しないとノイズになります。
+これらの高さは付属構造物自身の高さであって、建物の高さではありません。
+
+面積比が範囲内なら、対象タグの状態で候補の状態が決まります。判定の優先順位は
+「欠けている」→「食い違っている」→「一致している」の順です。
+
+| 状態 | 意味 | 表示 |
+|---|---|---|
+| `CANDIDATE` | 追加できるタグがある | マゼンタのドット（zoom 17〜） |
+| `CONFLICT` | OSM と Plateau で値が違う | ドット（zoom 18〜）+ 注記のみ |
+| `AREA_MISMATCH` | Plateau 外形が OSM 建物の 2 倍超 | オレンジの `!?`（zoom 18〜） |
+| `COVERED` | すべて存在し一致している | セクション自体を非表示 |
+
+### 適用
+
+建物を選択すると、エンティティエディタに「Plateauタグ転記」セクションが出ます。
+追加されるタグが読み取り専用で並び、「適用」ボタンか、選択中のみ有効な
+ショートカット `A` で転記できます。
+
+セクションの構造は、注記を出すかどうかを状態が決め、タグ表と適用ボタンを出すか
+どうかを「追加できるタグがあるか」が決める、という直交した形になっています。
+そのため `AREA_MISMATCH` でも、追加できるタグがあれば注記と一緒に適用ボタンが
+出ます。`CONFLICT` は状態の優先順位から追加できるタグが必ず空になるので、
+特別扱いなしに注記だけが表示されます。
+
+値の上書きは行いません。既存の OSM の値と食い違う場合は注記を出すだけで、
+上書きするかどうかはコミュニティでの合意を待っている段階です。
+
+## LOD2 リレーション対応
+
+Plateau の LOD2 建物は、外形と屋根などの部分が `type=building` リレーションで
+まとまっています。API 側がリレーションを出力し、クライアントはそれを解釈します。
+
+- リレーション単位の conflation（一部だけ OSM と重なる場合の判定）
+- 複数セクション建物の選択・ホバー時にメンバーをハイライト
+- 「Add Entire Feature」（リレーション全体）と「Add Only This Feature」
+  （その部分だけ）の使い分け。後者は `Shift+A`
+
+## Plateau対応エリア表示（zoom 5〜15）
+
+`PixiLayerPlateauCoverage` がPlateauデータが存在するエリアを半透明オレンジで表示します。
+
+- **データソース**: `GET /api/mapwithai/coverage` （都市単位のConcaveHull）
+- **表示ズーム**: 5〜15（16 以上で実際の建物データに切り替わるため自動非表示）
+- **色**: `#FE6100`（IBM Accessible Color Palette、色覚バリアフリー対応）
+- **モジュール**: `modules/pixi/PixiLayerPlateauCoverage.js`
+- **API 取得**: `PlateauService.loadCoverage()` でセッション内キャッシュ
+
+サーバ側の `plateau_coverage` マテリアライズドビューが必要です。
+詳細は [rapid_plateau_api README](https://github.com/nyampire/rapid_plateau_api) を参照してください。
+
+## クライアントサイド Conflation
+
+Plateau 建物が既存のOSM建物と重複する場合、自動的に非表示にする機能です。
+
+### 仕組み
+
+1. 表示範囲内のOSM建物を収集
+2. 各Plateau建物に対し、バウンディングボックスで事前フィルタ
+3. Polyclip ライブラリでポリゴン交差を精密判定
+4. 重複するPlateau建物を非表示にする
+
+### キャッシュ
+
+判定結果は `_plateauConflationCache`（`checked` / `rejected`）にキャッシュされ、
+OSMデータの変更時（`merge` イベント）に自動で無効化されます。
+
+### 無効化
+
+開発・デバッグ時にconflationを無効にしてすべてのPlateauデータを表示するには：
+
+```
+http://127.0.0.1:8080/#plateau_conflation=false
+```
+
+## テスト
+
+```bash
+npm run test:browser
+```
+
+Plateau 関連のテストは主に以下にあります。
+
+- `test/browser/services/PlateauService.test.js` — XMLパース、conflation、リレーション
+- `test/browser/core/lib/HeightTransferMatcher.test.js` — 候補判定と面積比
+- `test/browser/modes/HeightTransferMode.test.js` — 適用、ショートカット、再計算
+- `test/browser/ui/sections/plateau_tags.js` — エディタセクションの表示
+- `test/browser/core/RapidSystem.test.js` — データセットの追加・有効化・トグル
+
+## ローカル開発
+
+```bash
+npm install
+npm run start         # http://127.0.0.1:8080
+```
+
+### 翻訳の追加
+
+UI 文字列の英語ソースは `data/core.yaml` です。`data/l10n/core.en.json` は
+そこから生成されるので、直接編集しないでください。
+
+日本語訳のうちフォーク固有のキーは `data/l10n/core.ja.json` を直接編集します
+（本家の文字列は Transifex 由来です）。
+
+翻訳を足しても画面に出ないときは、ブラウザキャッシュを疑ってください。
+`data/l10n/*.min.json` はキャッシュが効くため、新しいキーが
+「Missing translation」のまま表示されることがあります。シークレット
+ウィンドウで開くと切り分けられます。
+
+## サーバ側との関係
+
+サーバ側リポジトリ: [nyampire/rapid_plateau_api](https://github.com/nyampire/rapid_plateau_api)
+
+クライアントが利用する主な API:
+
+- `GET /api/mapwithai/buildings?bbox=...` → OSM XML
+- `GET /api/mapwithai/coverage` → GeoJSON FeatureCollection（対応エリア）
+
+建物データには、タグ転記が使う `representative_point`（外形の内部にある代表点）が
+含まれます。ポリゴンが凹んでいる場合に重心が外に出てしまうため、重心ではなく
+内部に落ちる点を使っています。
+
+サーバ側のアーキテクチャやデータベース構造は、上記リポジトリの
+README / ARCHITECTURE.md を参照してください。
+
+## 関連 Issue
+
+未対応の課題や検討中の機能は
+[issue 一覧](https://github.com/nyampire/Rapid/issues) を参照してください。

--- a/PLATEAU.md
+++ b/PLATEAU.md
@@ -1,114 +1,232 @@
-# Plateau 開発者向け情報
+# Plateau Import Features — Developer Guide
 
-このドキュメントは、Rapid エディタにおける Plateau データ統合に関する開発者向け情報をまとめたものです。
+*日本語版: [PLATEAU.ja.md](PLATEAU.ja.md)*
 
-## アーキテクチャ概要
+This guide covers the features this fork adds to Rapid for importing Plateau
+building data into OpenStreetMap: how they are implemented and how to work on
+them.
 
-Plateau データは `MapWithAIService`（`modules/services/MapWithAIService.js`）を通じて取得・管理されます。
+This fork deals with **Plateau building data only**. Plateau also publishes
+bridges, tunnels, vegetation and other categories; those are out of scope.
 
-- **データセットID**: `plateauJapan`
-- **サービス**: `mapwithai`
-- **データ形式**: OSM XML
-- **タイルズームレベル**: 16以上
+The project spans three repositories.
+
+| Repository | Role |
+|---|---|
+| [nyampire/Rapid](https://github.com/nyampire/Rapid) | The editor (this repository) |
+| [nyampire/rapid_plateau_api](https://github.com/nyampire/rapid_plateau_api) | Backend that serves the building data |
+| [nyampire/rapid_plateau_dashboard](https://github.com/nyampire/rapid_plateau_dashboard) | Visualization of import progress |
+
+## Architecture overview
+
+Plateau data is fetched and managed by `PlateauService`
+(`modules/services/PlateauService.js`).
+
+- **Dataset ID**: `plateauJapan`
+- **Data format**: OSM XML
+- **Tile zoom**: 16 and above
+
+Plateau-specific handling (relations, conflation, coverage, highlighting) is
+kept independent of upstream's MapWithAI / PMTiles code, so that
+`git merge upstream/main` does not drag Plateau into the conflict.
+
+Data emitted by this service carries `__service__ = 'plateau'`.
+
+### Plateau-specific modules
+
+| Module | Role |
+|---|---|
+| `modules/services/PlateauService.js` | API fetching, relation assembly, conflation, coverage |
+| `modules/pixi/PixiLayerPlateauCoverage.js` | Coverage area fill |
+| `modules/pixi/PixiLayerHeightTransfer.js` | Tag-transfer candidate dots |
+| `modules/modes/HeightTransferMode.js` | Tag-transfer mode: recompute and apply |
+| `modules/core/lib/HeightTransferMatcher.js` | Matches Plateau outlines to OSM buildings |
+| `modules/ui/sections/plateau_tags.js` | Tag-transfer section in the entity editor |
+| `modules/actions/transfer_plateau_tags.js` | The edit action that adds the tags |
 
 ## Plateau API
 
-### 本番URL
+### Production URL
 
 ```
 https://rapid.nyampire.info/api/mapwithai/buildings
 ```
 
-`MapWithAIService.js` の `PLATEAU_API_URL` 定数にハードコードされています。
+Hardcoded in the `PLATEAU_API_URL` constant in `PlateauService.js`.
 
-### ローカル開発時のAPI切り替え
+### Pointing at a local API
 
-URLハッシュパラメータでAPIエンドポイントをランタイムで上書きできます。
+The endpoint can be overridden at runtime with a URL hash parameter.
 
 ```
 http://127.0.0.1:8080/#plateau_api_url=http://localhost:8000/api/mapwithai/buildings
 ```
 
-ローカルで Plateau API サーバー（`rapid_plateau_api`）を起動し、上記のようにアクセスすることで、本番APIの代わりにローカルAPIを使用できます。
+Run the Plateau API server (`rapid_plateau_api`) locally and load the editor as
+above to use it instead of production.
 
-## URLハッシュパラメータ一覧
+## URL hash parameters
 
-| パラメータ | 説明 | 例 |
+| Parameter | Purpose | Example |
 |---|---|---|
-| `plateau_api_url` | Plateau APIエンドポイントの上書き | `#plateau_api_url=http://localhost:8000/api/mapwithai/buildings` |
-| `plateau_conflation` | クライアントサイドconflationの無効化 | `#plateau_conflation=false` |
+| `plateau_api_url` | Override the Plateau API endpoint | `#plateau_api_url=http://localhost:8000/api/mapwithai/buildings` |
+| `plateau_conflation` | Disable client-side conflation | `#plateau_conflation=false` |
 
-## Plateau対応エリア表示（zoom 5〜14）
+## Tag transfer (height / ele / building:levels)
 
-`PixiLayerPlateauCoverage` がPlateauデータが存在するエリアを半透明オレンジで表示します。
+Transfers the height information Plateau carries onto existing OSM buildings.
+Enabled from the "Tag transfer mode" toolbar button.
 
-- **データソース**: `GET /api/mapwithai/coverage` （都市単位のConcaveHull）
-- **表示ズーム**: 5〜14（15以上で実際の建物データに切り替わるため自動非表示）
-- **色**: `#FE6100`（IBM Accessible Color Palette、色覚バリアフリー対応）
-- **モジュール**: `modules/pixi/PixiLayerPlateauCoverage.js`
-- **API 取得**: `MapWithAIService.loadCoverage()` でセッション内キャッシュ
+The target tags are `height`, `ele` and `building:levels`.
 
-サーバ側の `plateau_coverage` マテリアライズドビューが必要。
-詳細は [rapid_plateau_api README](https://github.com/nyampire/rapid_plateau_api) 参照。
+### How candidates are found
 
-## クライアントサイド Conflation
+`HeightTransferMatcher.findCandidates()` looks for the OSM building that
+contains the Plateau outline's representative point (the `representative_point`
+the API returns). A candidate is formed only when exactly one building contains
+it — zero or several are ambiguous and are skipped.
 
-Plateau 建物が既存のOSM建物と重複する場合、自動的に非表示にする機能です。
+It then looks at the area ratio (Plateau outline ÷ OSM building).
 
-### 仕組み
+| Area ratio | Treatment |
+|---|---|
+| Below 0.5 | Dropped from the candidate list |
+| 0.5 to 2.0 | Decided by tag state (see below) |
+| Above 2.0 | `AREA_MISMATCH` |
 
-1. 表示範囲内のOSM建物を収集
-2. 各Plateau建物に対し、バウンディングボックスで事前フィルタ
-3. Polyclip ライブラリでポリゴン交差を精密判定
-4. 重複するPlateau建物を非表示にする
+Outlines below 0.5 are dropped because Plateau models ancillary structures —
+rooftop stair enclosures, sheds — as their own `building=yes` rather than
+`building:part`. Their representative points land inside the larger OSM
+building, so without this rule they are pure noise. Their heights describe the
+ancillary structure, not the building.
 
-### キャッシュ
+When the ratio is in range, the state comes from the target tags. Precedence is
+missing → conflicting → matching.
 
-判定結果は `_plateauConflationCache`（`checked` / `rejected`）にキャッシュされ、OSMデータの変更時（`merge` イベント）に自動で無効化されます。
+| State | Meaning | Display |
+|---|---|---|
+| `CANDIDATE` | There are tags to add | Magenta dot (zoom 17+) |
+| `CONFLICT` | OSM and Plateau values differ | Dot (zoom 18+) and a note only |
+| `AREA_MISMATCH` | Plateau outline over twice the OSM building | Orange `!?` (zoom 18+) |
+| `COVERED` | All present and matching | Section hidden entirely |
 
-### 無効化
+### Applying
 
-開発・デバッグ時にconflationを無効にしてすべてのPlateauデータを表示するには：
+Selecting a building shows a "Plateau tag transfer" section in the entity
+editor. The tags to be added are listed read-only, and can be transferred with
+the Apply button or the `A` shortcut, which is bound only while such a building
+is selected.
+
+The section is structured so that the state decides whether a note appears,
+while the presence of tags to add decides whether the table and Apply button
+appear. Those two are independent, which is why an `AREA_MISMATCH` still offers
+the Apply button alongside its warning note. A `CONFLICT` needs no special case:
+state precedence guarantees it has no tags to add, so it shows the note alone.
+
+Existing values are never overwritten. Where OSM and Plateau disagree the
+section only shows a note; whether to overwrite is pending community
+consultation.
+
+## LOD2 relation support
+
+Plateau LOD2 buildings consist of an outline plus parts such as roof sections,
+grouped by a `type=building` relation. The API emits the relations and the
+client interprets them.
+
+- Conflation at relation granularity (when only part of it overlaps OSM)
+- Highlighting relation members on select and hover for multi-section buildings
+- "Add Entire Feature" (the whole relation) versus "Add Only This Feature"
+  (just that part). The latter is `Shift+A`
+
+## Coverage display (zoom 5-15)
+
+`PixiLayerPlateauCoverage` shows the areas where Plateau data exists as a
+translucent orange fill.
+
+- **Data source**: `GET /api/mapwithai/coverage` (per-city concave hulls)
+- **Zoom range**: 5-15 (hidden from 16, where the actual building data takes over)
+- **Colour**: `#FE6100` (IBM Accessible Color Palette, colour-blind safe)
+- **Module**: `modules/pixi/PixiLayerPlateauCoverage.js`
+- **Fetching**: `PlateauService.loadCoverage()`, cached for the session
+
+Requires the `plateau_coverage` materialized view on the server. See the
+[rapid_plateau_api README](https://github.com/nyampire/rapid_plateau_api).
+
+## Client-side conflation
+
+Hides Plateau buildings that overlap an existing OSM building.
+
+### How it works
+
+1. Collect the OSM buildings in view
+2. Pre-filter each Plateau building by bounding box
+3. Decide polygon intersection precisely with the Polyclip library
+4. Hide the overlapping Plateau buildings
+
+### Caching
+
+Results are cached in `_plateauConflationCache` (`checked` / `rejected`) and
+invalidated automatically when OSM data changes (the `merge` event).
+
+### Disabling
+
+To show all Plateau data with conflation off, for development or debugging:
 
 ```
 http://127.0.0.1:8080/#plateau_conflation=false
 ```
 
-## テスト
-
-Plateau 関連のテストは以下のファイルにあります：
-
-- `test/browser/services/MapWithAIService.test.js` — XMLパース、conflationロジック
-- `test/browser/core/RapidSystem.test.js` — データセットの追加・有効化・無効化・トグル
+## Tests
 
 ```bash
 npm run test:browser
 ```
 
-## 過去の主要な変更
+The Plateau tests live mainly in:
 
-- **対応エリア表示**: [#9](https://github.com/nyampire/Rapid/issues/9) ✅ 完了 (PR #10)
-  - `PixiLayerPlateauCoverage` 追加
-  - サーバ側 [rapid_plateau_api #10](https://github.com/nyampire/rapid_plateau_api/pull/10) でAPI実装
-- **デフォルト表示位置**: 日本に変更（zoom 5.52/36.934/139.144）
-- **OAuth client_id**: Plateau 用にハードコード変更（PR #8）
+- `test/browser/services/PlateauService.test.js` — XML parsing, conflation, relations
+- `test/browser/core/lib/HeightTransferMatcher.test.js` — candidate rules and area ratio
+- `test/browser/modes/HeightTransferMode.test.js` — apply, shortcut, recompute
+- `test/browser/ui/sections/plateau_tags.js` — the editor section
+- `test/browser/core/RapidSystem.test.js` — dataset add / enable / toggle
 
-## 関連 Issue（オープン）
+## Local development
 
-- [#3 Keyboard shortcut conflict (R / Shift+R)](https://github.com/nyampire/Rapid/issues/3)
-- [#4 選択中のOSMオブジェクトと重複するPlateauオブジェクトを検索・表示する機能](https://github.com/nyampire/Rapid/issues/4)
-- [#5 OSM建物のジオメトリをPlateauジオメトリで置換する機能（履歴保持）](https://github.com/nyampire/Rapid/issues/5)
-- [#6 Plateau APIエラー時のフォールバックとユーザー通知の改善](https://github.com/nyampire/Rapid/issues/6)
-- [#7 ビルド時にclient_id/client_secretを環境変数から注入する仕組み](https://github.com/nyampire/Rapid/issues/7)
-- [#8 PlateauからOSMへのタグマッピングルールのカスタマイズ機能](https://github.com/nyampire/Rapid/issues/8)
-- [#11 テストカバレッジの拡充](https://github.com/nyampire/Rapid/issues/11)
+```bash
+npm install
+npm run start         # http://127.0.0.1:8080
+```
 
-## サーバ側との関係
+### Adding translations
 
-サーバ側リポジトリ: [nyampire/rapid_plateau_api](https://github.com/nyampire/rapid_plateau_api)
+The English source for UI strings is `data/core.yaml`. `data/l10n/core.en.json`
+is generated from it — do not edit that file directly.
 
-クライアントが利用する主な API:
+Fork-specific Japanese strings are edited directly in `data/l10n/core.ja.json`
+(upstream's strings come from Transifex).
+
+If a string you added does not show up, suspect the browser cache.
+`data/l10n/*.min.json` is cached, so a new key can keep rendering as
+"Missing translation" until the cache turns over. An incognito window tells the
+two apart.
+
+## Relationship to the server
+
+Server repository: [nyampire/rapid_plateau_api](https://github.com/nyampire/rapid_plateau_api)
+
+The main APIs the client uses:
+
 - `GET /api/mapwithai/buildings?bbox=...` → OSM XML
-- `GET /api/mapwithai/coverage` → GeoJSON FeatureCollection（対応エリア）
+- `GET /api/mapwithai/coverage` → GeoJSON FeatureCollection (coverage areas)
 
-サーバ側のアーキテクチャやデータベース構造は、上記リポジトリの README / ARCHITECTURE.md 参照。
+Building data includes `representative_point`, a point guaranteed to fall inside
+the outline, which tag transfer uses. An interior point is used rather than a
+centroid because the centroid of a concave polygon can fall outside it.
+
+For the server's architecture and database schema, see that repository's
+README / ARCHITECTURE.md.
+
+## Issues
+
+For open problems and features under discussion, see the
+[issue tracker](https://github.com/nyampire/Rapid/issues).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+> ## This is a fork with added features for importing Plateau data
+>
+> This repository is a fork of [facebook/Rapid](https://github.com/facebook/Rapid) with
+> added features for importing building data from [Plateau](https://www.mlit.go.jp/plateau/),
+> Japan's open 3D city model published by the Ministry of Land, Infrastructure, Transport
+> and Tourism, into OpenStreetMap. A running instance is at **<https://rapid.nyampire.info/>**.
+>
+> For what this fork adds, how it is built, and how to work on it, see
+> **[PLATEAU.md](PLATEAU.md)** (日本語版: **[PLATEAU.ja.md](PLATEAU.ja.md)**).
+> The procedure for pulling in upstream releases is in [UPSTREAM_MERGE.md](UPSTREAM_MERGE.md).
+>
+> Everything below is upstream Rapid's own README, left as-is. Where it differs for this
+> fork — such as where to file issues or feature requests — PLATEAU.md takes precedence.
+
+---
+
 [![build](https://github.com/facebook/Rapid/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/facebook/Rapid/actions/workflows/build.yml)
 [![npm version](https://badge.fury.io/js/%40rapideditor%2Frapid.svg)](https://badge.fury.io/js/%40rapideditor%2Frapid)
 

--- a/data/core.yaml
+++ b/data/core.yaml
@@ -1199,7 +1199,7 @@ en:
         description: "Road network data sourced from TomTom, available through the Overture Maps Foundation."
     plateauJapan:
       label: Plateau Japan Buildings
-      description: Building footprints from Japan's PLATEAU 3D city model project, provided by OSMFJ.
+      description: Building footprints from Japan's Plateau 3D city model project, provided by OSMFJ.
     ignored_ids:
       link: "{count} ignored Overture IDs"
       link_one: "{count} ignored Overture ID"
@@ -1635,8 +1635,8 @@ en:
       open_source_h: "Open Source"
       open_source: "The Rapid editor is a collaborative open source project, and you are using version {version} now. The source code is available [on GitHub](https://github.com/facebook/Rapid)."
       open_source_help: "You can help Rapid by [reporting bugs](https://github.com/facebook/Rapid/issues)."
-      open_source_plateau_h: "PLATEAU Edition"
-      open_source_plateau: "This edition extends Rapid with integration for [PLATEAU](https://www.mlit.go.jp/plateau/), Japan's open 3D city data. It spans three repositories:\n\n- [Editor](https://github.com/nyampire/Rapid) — this fork of Rapid\n- [API](https://github.com/nyampire/rapid_plateau_api) — backend that serves PLATEAU building data\n- [Dashboard](https://github.com/nyampire/rapid_plateau_dashboard) — visualization of import progress"
+      open_source_plateau_h: "About the Plateau import features"
+      open_source_plateau: "This is a fork of Rapid with added features for importing building data from [Plateau](https://www.mlit.go.jp/plateau/), Japan's open 3D city model, into OpenStreetMap. It spans three repositories:\n\n- [Editor](https://github.com/nyampire/Rapid) — this fork of Rapid\n- [API](https://github.com/nyampire/rapid_plateau_api) — backend that serves Plateau building data\n- [Dashboard](https://github.com/nyampire/rapid_plateau_dashboard) — visualization of import progress"
     overview:
       title: Overview
       navigation_h: "Navigation"
@@ -2671,7 +2671,7 @@ en:
         key: D   # <this key> to Ignore a suggested feature
       apply_plateau_tags:
         label: Apply Plateau tags to the selected building
-        key: A   # <this key> to apply the PLATEAU tags (bound only while a candidate building is selected)
+        key: A   # <this key> to apply the Plateau tags (bound only while a candidate building is selected)
 
       follow_sequence:
         label: Step to next / previous photo in sequence

--- a/data/l10n/core.en.json
+++ b/data/l10n/core.en.json
@@ -1493,7 +1493,7 @@
       },
       "plateauJapan": {
         "label": "Plateau Japan Buildings",
-        "description": "Building footprints from Japan's PLATEAU 3D city model project, provided by OSMFJ."
+        "description": "Building footprints from Japan's Plateau 3D city model project, provided by OSMFJ."
       },
       "ignored_ids": {
         "link": "{count} ignored Overture IDs",
@@ -2022,8 +2022,8 @@
         "open_source_h": "Open Source",
         "open_source": "The Rapid editor is a collaborative open source project, and you are using version {version} now. The source code is available [on GitHub](https://github.com/facebook/Rapid).",
         "open_source_help": "You can help Rapid by [reporting bugs](https://github.com/facebook/Rapid/issues).",
-        "open_source_plateau_h": "PLATEAU Edition",
-        "open_source_plateau": "This edition extends Rapid with integration for [PLATEAU](https://www.mlit.go.jp/plateau/), Japan's open 3D city data. It spans three repositories:\n\n- [Editor](https://github.com/nyampire/Rapid) — this fork of Rapid\n- [API](https://github.com/nyampire/rapid_plateau_api) — backend that serves PLATEAU building data\n- [Dashboard](https://github.com/nyampire/rapid_plateau_dashboard) — visualization of import progress"
+        "open_source_plateau_h": "About the Plateau import features",
+        "open_source_plateau": "This is a fork of Rapid with added features for importing building data from [Plateau](https://www.mlit.go.jp/plateau/), Japan's open 3D city model, into OpenStreetMap. It spans three repositories:\n\n- [Editor](https://github.com/nyampire/Rapid) — this fork of Rapid\n- [API](https://github.com/nyampire/rapid_plateau_api) — backend that serves Plateau building data\n- [Dashboard](https://github.com/nyampire/rapid_plateau_dashboard) — visualization of import progress"
       },
       "overview": {
         "title": "Overview",

--- a/data/l10n/core.ja.json
+++ b/data/l10n/core.ja.json
@@ -866,8 +866,8 @@
         "open_source": "iDエディタは共同作業のオープンソースプロジェクトであり、現在のバージョンは{version} です。ソースコードは[GitHub上](https://github.com/openstreetmap/iD)にあります。",
         "open_source_h": "オープンソース",
         "open_source_help": "あなたも[翻訳](https://github.com/openstreetmap/iD/blob/develop/CONTRIBUTING.md#translating)したり[バグ報告](https://github.com/openstreetmap/iD/issues)したりすることでiDを支援できます。",
-        "open_source_plateau_h": "PLATEAU 統合版について",
-        "open_source_plateau": "このエディタは [PLATEAU](https://www.mlit.go.jp/plateau/) (国土交通省が公開する 3D 都市データ) を統合した Rapid のフォークです。次の 3 リポジトリで構成されています:\n\n- [Editor](https://github.com/nyampire/Rapid) — このフォーク (本リポジトリ)\n- [API](https://github.com/nyampire/rapid_plateau_api) — PLATEAU 建物データを配信するバックエンド\n- [Dashboard](https://github.com/nyampire/rapid_plateau_dashboard) — インポート進捗の可視化",
+        "open_source_plateau_h": "Plateau インポート機能について",
+        "open_source_plateau": "このエディタは、[Plateau](https://www.mlit.go.jp/plateau/) (国土交通省が公開する 3D 都市モデル) の建築物データを OpenStreetMap にインポートする作業を支援する機能を追加した Rapid のフォークです。次の 3 リポジトリで構成されています:\n\n- [Editor](https://github.com/nyampire/Rapid) — このフォーク (本リポジトリ)\n- [API](https://github.com/nyampire/rapid_plateau_api) — Plateau 建物データを配信するバックエンド\n- [Dashboard](https://github.com/nyampire/rapid_plateau_dashboard) — インポート進捗の可視化",
         "title": "ヘルプ",
         "welcome": "[OpenStreetMap](https://www.openstreetmap.org/)用のiDエディタへようこそ。このエディタを使うと自分のブラウザから直接OpenStreetMapを更新できます。"
       },


### PR DESCRIPTION
README とガイドが実装から離れていたので、内容を更新し、英語版と日本語版の両方を用意しました。

## README

`README.md` は本家 Rapid のものがそのまま残っていて、リポジトリを訪れた人がこれが Plateau 用のフォークだと気づけない状態でした。冒頭に英語で短い説明を置き、ガイドと稼働中のインスタンスへ誘導しています。

本家の本文はそのまま残しました。`git merge upstream/main` で競合するのはこの数行だけに収まります。

## ガイドの二言語化

他のフォーク向け doc（`UPSTREAM_MERGE.md`、`DEPLOY.md`）が既に英語だったので、その慣習に合わせました。`PLATEAU.md` が英語、`PLATEAU.ja.md` が日本語で、両方の冒頭から相互にリンクしています。見出しは 21 対 21 で 1 対 1 に対応させてあり、片方だけ加筆されて内容がずれない構成にしています。

タイトルも変更しました。旧題の「Plateau 開発者向け情報」は、Plateau そのものを開発する人向けの資料に読めてしまうためです。

## 内容の更新

5 月以降の実装とのズレを埋めました。

- Plateau の処理は `MapWithAIService` ではなく `PlateauService` が持つこと、および upstream のマージで巻き込まれないよう分離してあること
- タグ転記機能を新規に記述。対象タグ、`representative_point` による候補判定、面積比のルールと 0.5 未満を除外する理由、4 つの状態、セクションの表示条件
- LOD2 リレーション対応（issue #12〜#22）
- 対応エリア表示のズーム範囲が 5〜14 と書かれていた。コードは `MINZOOM 5` / `MAXZOOM 15`
- テストファイル一覧を実在するパスに修正
- 翻訳の編集場所と、新しいキーが「Missing translation」のまま表示されるキャッシュの挙動を追記
- 手書きのオープン issue 一覧を issue トラッカーへのリンクに置き換え。クローズ済み 3 件が残り、オープン 1 件が抜けていた状態で、コピーを持つ限り同じことが起きるため

## UI 文言

ヘルプが「PLATEAU 統合版」「extends Rapid with integration for PLATEAU」となっていて、このフォークが何をするものか説明できていませんでした。「Plateau の建築物データを OpenStreetMap にインポートする作業を支援する機能を追加したフォーク」と書き直しています。

あわせて表示文字列の `PLATEAU` を `Plateau` に統一しました（816700656 の続き）。`PLATEAU_API_URL` などの識別子はそのままです。

この文言変更はビルドとデプロイが必要なため、doc のみの変更とはコミットを分けてあります。

## 検証

doc 間のリンク 8 件と、doc が挙げるコード・テストのパス 12 件がすべて実在することを確認しました。テストは 727 件グリーン、ヘルプの表示は dev サーバで確認済みです。
